### PR TITLE
Remove openjdk8 in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 jdk:
   - openjdk7
-  - openjdk8
 
 install: ./gradlew setupCIWorkspace -S
 script: ./gradlew build


### PR DESCRIPTION
Travis doesn't support it (yet)

D: Sorry about this, I edited the .travis.yml right before the merge to enable openjdk8 builds, I didn't realize that travis doesn't have openjdk8

~~@alatyami Can you enable travis builds~~

EDIT:
Looks like it was enabled :)
