### PR TITLE
Infrastructure/artifact deployment to GitHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,8 @@ install: ./gradlew setupCIWorkspace -S
 
 script: 
  - ./gradlew build
-
+ - ls -la build/libs
+ 
 # Deploy the artifacts back to GitHub
 #deploy:
 #  provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,10 +12,10 @@ script:
  - ls -la build/libs
  
 # Deploy the artifacts back to GitHub
-#deploy:
-#  provider: releases
-#  api_key: "42c1b36e0833ce72af6b908b54c8259645e36191"
-#  file: "build/libs"
-# skip_cleanup: true
-#  on:
-#    tags: true
+deploy:
+  provider: releases
+  api_key: "42c1b36e0833ce72af6b908b54c8259645e36191"
+  file: "build/libs/growthcraft-2.2.1-complete.jar"
+  skip_cleanup: true
+  on:
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ script:
 # Deploy the artifacts back to GitHub
 deploy:
   provider: releases
-  api_key: "42c1b36e0833ce72af6b908b54c8259645e36191"
+  api_key: "ca3a06c1a8879fb27c97a1d36b6d058f33787bf4"
   file: "build/libs/growthcraft-2.2.1-complete.jar"
   skip_cleanup: true
   on:

--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,7 @@ dependencies {
 task sourceJar(type: Jar) {
     from sourceSets.main.allSource
     from sourceSets.api.allSource
+	from sourceSets.cellar.allSource
     classifier = 'sources'
 }
 
@@ -99,12 +100,18 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 task deobfJar(type: Jar) {
     from sourceSets.main.output
     from sourceSets.api.output
+	from sourceSets.cellar.output
     classifier = 'dev'
 }
 
 task apiJar(type: Jar) {
     from sourceSets.api.output
     classifier = 'api'
+}
+
+task cellarJar(type: Jar) {
+    from sourceSets.cellar.output
+    classifier = 'cellar'
 }
 
 // add api classes to main package

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,11 @@ sourceSets {
             srcDir 'src/java/growthcraft/api'
         }
     }
+    cellar {
+        java {
+            srcDir 'src/java/growthcraft/cellar'
+        }
+    }	
 }
 
 processResources {

--- a/build.gradle
+++ b/build.gradle
@@ -53,11 +53,6 @@ sourceSets {
             srcDir 'src/java/growthcraft/api'
         }
     }
-    cellar {
-        java {
-            srcDir 'src/java/growthcraft/cellar'
-        }
-    }	
 }
 
 processResources {
@@ -81,7 +76,6 @@ dependencies {
 task sourceJar(type: Jar) {
     from sourceSets.main.allSource
     from sourceSets.api.allSource
-	from sourceSets.cellar.allSource
     classifier = 'sources'
 }
 
@@ -100,7 +94,6 @@ task javadocJar(type: Jar, dependsOn: javadoc) {
 task deobfJar(type: Jar) {
     from sourceSets.main.output
     from sourceSets.api.output
-	from sourceSets.cellar.output
     classifier = 'dev'
 }
 
@@ -109,14 +102,10 @@ task apiJar(type: Jar) {
     classifier = 'api'
 }
 
-task cellarJar(type: Jar) {
-    from sourceSets.cellar.output
-    classifier = 'cellar'
-}
-
 // add api classes to main package
 jar {
   from sourceSets.api.output
+    classifier = 'complete'
 }
 
 // make sure all of these happen when we run build

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jul 02 15:54:47 CDT 2014
+#Wed Aug 12 18:13:10 EDT 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.0-all.zip


### PR DESCRIPTION
With this pull request we can now deploy our releases from travis-ci back to github. the release must be tagged. The current setup only deploys the complete growthcraft bundle as `growthcraft-version-complete.jar` for those that simply want the entire bundle. 

The next stage will be generating the individual sub-modules.
