### PR TITLE
Fixed Village Structure spawning

### DIFF
--- a/src/java/growthcraft/apples/village/ComponentVillageAppleFarm.java
+++ b/src/java/growthcraft/apples/village/ComponentVillageAppleFarm.java
@@ -74,7 +74,7 @@ public class ComponentVillageAppleFarm extends StructureVillagePieces.Village im
 
 	public static ComponentVillageAppleFarm buildComponent(Start startPiece, List list, Random random, int x, int y, int z, int coordBaseMode, int par7)
 	{
-		StructureBoundingBox structureboundingbox = StructureBoundingBox.getComponentToAddBoundingBox(x, y, z, 0, 0, 0, 13, 9, 13, coordBaseMode);
+		StructureBoundingBox structureboundingbox = StructureBoundingBox.getComponentToAddBoundingBox(x, y, z, 0, 0, 0, 11, 6, 11, coordBaseMode);
 		if (canVillageGoDeeper(structureboundingbox)) {
 			if (StructureComponent.findIntersecting(list, structureboundingbox) == null) {
 				return new ComponentVillageAppleFarm(startPiece, par7, random, structureboundingbox, coordBaseMode);
@@ -99,13 +99,11 @@ public class ComponentVillageAppleFarm extends StructureVillagePieces.Village im
 				return true;
 			}
 
-			this.boundingBox.offset(0, this.field_143015_k - this.boundingBox.maxY + 7, 0);
+			this.boundingBox.offset(0, this.field_143015_k - this.boundingBox.maxY + 5, 0);
 		}
 
 		// clear entire bounding box
-		this.fillWithBlocks(world, box, 0, 0, 0, 13, 9, 13, Blocks.air, Blocks.air, false);
-		// replace the base layer with grass
-		this.fillWithBlocks(world, box, 0, 0, 0, 13, 0, 13, Blocks.grass, Blocks.grass, false);
+		this.fillWithBlocks(world, box, 0, 0, 0, 11, 3, 11, Blocks.air, Blocks.air, false);
 
 		boolean vert = (this.coordBaseMode == 2 || this.coordBaseMode == 0);
 		HashMap<Character, IBlockEntries> map = new HashMap<Character, IBlockEntries>();
@@ -121,7 +119,15 @@ public class ComponentVillageAppleFarm extends StructureVillagePieces.Village im
 		// this should grow into an apple tree
 		map.put('s', new BlockEntry(GrowthCraftApples.appleSapling, 8));
 
-		SchemaToVillage.drawSchema(this, world, random, box, appleFarmSchema, map, 0, 1, 0);
+		SchemaToVillage.drawSchema(this, world, random, box, appleFarmSchema, map, 0, 0, 0);
+		for (int row = 0; row < 11; ++row)
+		{
+			for (int col = 0; col < 11; ++col)
+			{
+				this.clearCurrentPositionBlocksUpwards(world, col, 6, row, box);
+				this.func_151554_b(world, Blocks.dirt, 0, col, -1, row, box);
+			}
+		}
 		return true;
 	}
 }

--- a/src/java/growthcraft/apples/village/ComponentVillageAppleFarm.java
+++ b/src/java/growthcraft/apples/village/ComponentVillageAppleFarm.java
@@ -119,7 +119,7 @@ public class ComponentVillageAppleFarm extends StructureVillagePieces.Village im
 		// clear entire bounding box
 		this.fillWithBlocks(world, box, 0, 0, 0, 11, 3, 11, Blocks.air, Blocks.air, false);
 
-		boolean vert = (this.coordBaseMode == 2 || this.coordBaseMode == 0);
+		boolean vert = (this.coordBaseMode == 2 || this.coordBaseMode == 3);
 		HashMap<Character, IBlockEntries> map = new HashMap<Character, IBlockEntries>();
 		map.put('x', new BlockEntry(Blocks.log, 0));
 		map.put('-', new BlockEntry(Blocks.log, vert ? 4 : 8));

--- a/src/java/growthcraft/apples/village/ComponentVillageAppleFarm.java
+++ b/src/java/growthcraft/apples/village/ComponentVillageAppleFarm.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.lang.Math;
 
 import growthcraft.apples.GrowthCraftApples;
+import growthcraft.apples.world.WorldGenAppleTree;
 import growthcraft.core.GrowthCraftCore;
 import growthcraft.core.utils.SchemaToVillage.BlockEntry;
 import growthcraft.core.utils.SchemaToVillage.IBlockEntries;
@@ -14,6 +15,7 @@ import growthcraft.core.utils.SchemaToVillage;
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
+import net.minecraft.world.gen.feature.WorldGenerator;
 import net.minecraft.world.gen.structure.StructureBoundingBox;
 import net.minecraft.world.gen.structure.StructureComponent;
 import net.minecraft.world.gen.structure.StructureVillagePieces;
@@ -27,11 +29,11 @@ public class ComponentVillageAppleFarm extends StructureVillagePieces.Village im
 			"x---x x---x",
 			"|         |",
 			"|         |",
-			"|  s   s  |",
 			"|         |",
 			"|         |",
 			"|         |",
-			"|  s   s  |",
+			"|         |",
+			"|         |",
 			"|         |",
 			"|         |",
 			"x---------x"
@@ -74,7 +76,7 @@ public class ComponentVillageAppleFarm extends StructureVillagePieces.Village im
 
 	public static ComponentVillageAppleFarm buildComponent(Start startPiece, List list, Random random, int x, int y, int z, int coordBaseMode, int par7)
 	{
-		StructureBoundingBox structureboundingbox = StructureBoundingBox.getComponentToAddBoundingBox(x, y, z, 0, 0, 0, 11, 6, 11, coordBaseMode);
+		StructureBoundingBox structureboundingbox = StructureBoundingBox.getComponentToAddBoundingBox(x, y, z, 0, 0, 0, 11, 7, 11, coordBaseMode);
 		if (canVillageGoDeeper(structureboundingbox)) {
 			if (StructureComponent.findIntersecting(list, structureboundingbox) == null) {
 				return new ComponentVillageAppleFarm(startPiece, par7, random, structureboundingbox, coordBaseMode);
@@ -88,6 +90,18 @@ public class ComponentVillageAppleFarm extends StructureVillagePieces.Village im
 		placeBlockAtCurrentPosition(world, block, meta, x, y, z, box);
 	}
 
+	protected void placeWorldGenAt(World world, Random random, int tx, int ty, int tz, StructureBoundingBox bb, WorldGenerator generator)
+    {
+        int x = this.getXWithOffset(tx, tz);
+        int y = this.getYWithOffset(ty);
+        int z = this.getZWithOffset(tx, tz);
+
+        if (bb.isVecInside(x, y, z))
+        {
+            generator.generate(world, random, x, y, z);
+        }
+    }
+
 	public boolean addComponentParts(World world, Random random, StructureBoundingBox box)
 	{
 		if (this.field_143015_k < 0)
@@ -99,7 +113,7 @@ public class ComponentVillageAppleFarm extends StructureVillagePieces.Village im
 				return true;
 			}
 
-			this.boundingBox.offset(0, this.field_143015_k - this.boundingBox.maxY + 5, 0);
+			this.boundingBox.offset(0, this.field_143015_k - this.boundingBox.maxY + 6, 0);
 		}
 
 		// clear entire bounding box
@@ -115,16 +129,19 @@ public class ComponentVillageAppleFarm extends StructureVillagePieces.Village im
 		map.put('g', new BlockEntry(Blocks.fence_gate, this.getMetadataWithOffset(Blocks.fence_gate, 0)));
 		map.put('t', new BlockEntry(Blocks.torch, 0));
 
-		// not sure how to place an apple tree, but we can place a sapling with its maximum metadata set, by the next tick
-		// this should grow into an apple tree
-		map.put('s', new BlockEntry(GrowthCraftApples.appleSapling, 8));
-
 		SchemaToVillage.drawSchema(this, world, random, box, appleFarmSchema, map, 0, 0, 0);
+
+		WorldGenAppleTree genAppleTree = new WorldGenAppleTree(true);
+		placeWorldGenAt(world, random, 3, 0, 3, box, genAppleTree);
+		placeWorldGenAt(world, random, 7, 0, 3, box, genAppleTree);
+		placeWorldGenAt(world, random, 3, 0, 7, box, genAppleTree);
+		placeWorldGenAt(world, random, 7, 0, 7, box, genAppleTree);
+
 		for (int row = 0; row < 11; ++row)
 		{
 			for (int col = 0; col < 11; ++col)
 			{
-				this.clearCurrentPositionBlocksUpwards(world, col, 6, row, box);
+				this.clearCurrentPositionBlocksUpwards(world, col, 7, row, box);
 				this.func_151554_b(world, Blocks.dirt, 0, col, -1, row, box);
 			}
 		}

--- a/src/java/growthcraft/apples/village/ComponentVillageAppleFarm.java
+++ b/src/java/growthcraft/apples/village/ComponentVillageAppleFarm.java
@@ -64,6 +64,7 @@ public class ComponentVillageAppleFarm extends StructureVillagePieces.Village im
 		},
 	};
 
+	public ComponentVillageAppleFarm() {} // DO NOT REMOVE
 	public ComponentVillageAppleFarm(Start startPiece, int par2, Random random, StructureBoundingBox boundingBox, int coordBaseMode)
 	{
 		super(startPiece, par2);

--- a/src/java/growthcraft/apples/village/ComponentVillageAppleFarm.java
+++ b/src/java/growthcraft/apples/village/ComponentVillageAppleFarm.java
@@ -73,7 +73,7 @@ public class ComponentVillageAppleFarm extends StructureVillagePieces.Village im
 
 	public static ComponentVillageAppleFarm buildComponent(Start startPiece, List list, Random random, int x, int y, int z, int coordBaseMode, int par7)
 	{
-		StructureBoundingBox structureboundingbox = StructureBoundingBox.getComponentToAddBoundingBox(x, y, z, 0, 0, 0, 13, 4, 13, coordBaseMode);
+		StructureBoundingBox structureboundingbox = StructureBoundingBox.getComponentToAddBoundingBox(x, y, z, 0, 0, 0, 13, 9, 13, coordBaseMode);
 		if (canVillageGoDeeper(structureboundingbox)) {
 			if (StructureComponent.findIntersecting(list, structureboundingbox) == null) {
 				return new ComponentVillageAppleFarm(startPiece, par7, random, structureboundingbox, coordBaseMode);
@@ -98,8 +98,13 @@ public class ComponentVillageAppleFarm extends StructureVillagePieces.Village im
 				return true;
 			}
 
-			this.boundingBox.offset(0, this.field_143015_k - this.boundingBox.maxY + 4 - 1, 0);
+			this.boundingBox.offset(0, this.field_143015_k - this.boundingBox.maxY + 7, 0);
 		}
+
+		// clear entire bounding box
+		this.fillWithBlocks(world, box, 0, 0, 0, 13, 9, 13, Blocks.air, Blocks.air, false);
+		// replace the base layer with grass
+		this.fillWithBlocks(world, box, 0, 0, 0, 13, 0, 13, Blocks.grass, Blocks.grass, false);
 
 		boolean vert = (this.coordBaseMode == 2 || this.coordBaseMode == 0);
 		HashMap<Character, IBlockEntries> map = new HashMap<Character, IBlockEntries>();
@@ -115,7 +120,7 @@ public class ComponentVillageAppleFarm extends StructureVillagePieces.Village im
 		// this should grow into an apple tree
 		map.put('s', new BlockEntry(GrowthCraftApples.appleSapling, 8));
 
-		SchemaToVillage.drawSchema(this, world, random, box, appleFarmSchema, map);
+		SchemaToVillage.drawSchema(this, world, random, box, appleFarmSchema, map, 0, 1, 0);
 		return true;
 	}
 }

--- a/src/java/growthcraft/bamboo/village/ComponentVillageBambooYard.java
+++ b/src/java/growthcraft/bamboo/village/ComponentVillageBambooYard.java
@@ -139,7 +139,6 @@ public class ComponentVillageBambooYard extends StructureVillagePieces.Village i
 		this.fillWithBlocks(world, box, 0, 0, 0, 11, 4, 12, Blocks.air, Blocks.air, false);
 		this.fillWithBlocks(world, box, 0, 0, 0, 11, 0, 12, Blocks.grass, Blocks.grass, false);
 
-		boolean vert = (this.coordBaseMode == 2 || this.coordBaseMode == 0);
 		HashMap<Character, IBlockEntries> map = new HashMap<Character, IBlockEntries>();
 
 		map.put('D', new BlockEntry(GrowthCraftBamboo.bambooDoor, this.getMetadataWithOffset(GrowthCraftBamboo.bambooDoor, 2))); // okay folks, no BIG D jokes here

--- a/src/java/growthcraft/bamboo/village/ComponentVillageBambooYard.java
+++ b/src/java/growthcraft/bamboo/village/ComponentVillageBambooYard.java
@@ -91,7 +91,8 @@ public class ComponentVillageBambooYard extends StructureVillagePieces.Village i
 
 	public static ComponentVillageBambooYard buildComponent(Start startPiece, List list, Random random, int x, int y, int z, int coordBaseMode, int par7)
 	{
-		StructureBoundingBox structureboundingbox = StructureBoundingBox.getComponentToAddBoundingBox(x, y, z, 0, 0, 0, 13, 4, 13, coordBaseMode);
+		// the height of the structure is 15 blocks, since the maximum height of bamboo is 12~14 blocks (+1 for the water layer)
+		StructureBoundingBox structureboundingbox = StructureBoundingBox.getComponentToAddBoundingBox(x, y, z, 0, 0, 0, 11, 15, 12, coordBaseMode);
 		if (canVillageGoDeeper(structureboundingbox)) {
 			if (StructureComponent.findIntersecting(list, structureboundingbox) == null) {
 				return new ComponentVillageBambooYard(startPiece, par7, random, structureboundingbox, coordBaseMode);
@@ -116,9 +117,13 @@ public class ComponentVillageBambooYard extends StructureVillagePieces.Village i
 				return true;
 			}
 
-			this.boundingBox.offset(0, this.field_143015_k - this.boundingBox.maxY + 3 - 1, 0);
+			// the structure is 1 block lower due to the water layer
+			this.boundingBox.offset(0, this.field_143015_k - this.boundingBox.maxY + 13, 0);
 		}
 
+		// clear entire bounding box
+		this.fillWithBlocks(world, box, 0, 0, 0, 11, 4, 12, Blocks.air, Blocks.air, false);
+		this.fillWithBlocks(world, box, 0, 0, 0, 11, 0, 12, Blocks.grass, Blocks.grass, false);
 		boolean vert = (this.coordBaseMode == 2 || this.coordBaseMode == 0);
 		HashMap<Character, IBlockEntries> map = new HashMap<Character, IBlockEntries>();
 
@@ -132,6 +137,16 @@ public class ComponentVillageBambooYard extends StructureVillagePieces.Village i
 		map.put('W', new BlockEntry(GrowthCraftBamboo.bambooWall, 0));
 
 		SchemaToVillage.drawSchema(this, world, random, box, bambooYardSchema, map);
+
+		for (int row = 0; row < 12; ++row)
+		{
+			for (int col = 0; col < 11; ++col)
+			{
+				this.clearCurrentPositionBlocksUpwards(world, col, 15, row, box);
+				this.func_151554_b(world, Blocks.dirt, 0, col, -1, row, box);
+			}
+		}
+
 		return true;
 	}
 }

--- a/src/java/growthcraft/bamboo/village/ComponentVillageBambooYard.java
+++ b/src/java/growthcraft/bamboo/village/ComponentVillageBambooYard.java
@@ -81,6 +81,7 @@ public class ComponentVillageBambooYard extends StructureVillagePieces.Village i
 		},
 	};
 
+	public ComponentVillageBambooYard() {} // DO NOT REMOVE
 	public ComponentVillageBambooYard(Start startPiece, int par2, Random random, StructureBoundingBox boundingBox, int coordBaseMode)
 	{
 		super(startPiece, par2);

--- a/src/java/growthcraft/bamboo/village/ComponentVillageBambooYard.java
+++ b/src/java/growthcraft/bamboo/village/ComponentVillageBambooYard.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.lang.Math;
 
 import growthcraft.bamboo.GrowthCraftBamboo;
+import growthcraft.bamboo.world.WorldGenBamboo;
 import growthcraft.core.GrowthCraftCore;
 import growthcraft.core.utils.SchemaToVillage.BlockEntry;
 import growthcraft.core.utils.SchemaToVillage.IBlockEntries;
@@ -14,6 +15,7 @@ import growthcraft.core.utils.SchemaToVillage;
 import net.minecraft.block.Block;
 import net.minecraft.init.Blocks;
 import net.minecraft.world.World;
+import net.minecraft.world.gen.feature.WorldGenerator;
 import net.minecraft.world.gen.structure.StructureBoundingBox;
 import net.minecraft.world.gen.structure.StructureComponent;
 import net.minecraft.world.gen.structure.StructureVillagePieces;
@@ -23,7 +25,7 @@ public class ComponentVillageBambooYard extends StructureVillagePieces.Village i
 {
 	// Design by Ar97x
 	static private final String bambooYardSchema[][] = {
-		{
+		{ // y: -1
 			"           ",
 			"           ",
 			"           ",
@@ -37,21 +39,21 @@ public class ComponentVillageBambooYard extends StructureVillagePieces.Village i
 			"           ",
 			"           "
 		},
-		{
+		{ // y: 0
 			"    pDp    ",
 			"ppppp ppppp",
 			"p         p",
 			"p t     t p",
-			"p   bsb   p",
-			"p  bs sb  p",
+			"p    s    p",
+			"p   s s   p",
 			"p  s   s  p",
-			"p  bs sb  p",
-			"p   bsb   p",
+			"p   s s   p",
+			"p    s    p",
 			"p t     t p",
 			"p         p",
 			"ppppppppppp"
 		},
-		{
+		{ // y: 1
 			"    WdW    ",
 			"W   W W   W",
 			"           ",
@@ -65,7 +67,7 @@ public class ComponentVillageBambooYard extends StructureVillagePieces.Village i
 			"           ",
 			"W         W"
 		},
-		{
+		{ // y: 2
 			"    WWW    ",
 			"WWWWW WWWWW",
 			"W         W",
@@ -92,7 +94,7 @@ public class ComponentVillageBambooYard extends StructureVillagePieces.Village i
 	public static ComponentVillageBambooYard buildComponent(Start startPiece, List list, Random random, int x, int y, int z, int coordBaseMode, int par7)
 	{
 		// the height of the structure is 15 blocks, since the maximum height of bamboo is 12~14 blocks (+1 for the water layer)
-		StructureBoundingBox structureboundingbox = StructureBoundingBox.getComponentToAddBoundingBox(x, y, z, 0, 0, 0, 11, 15, 12, coordBaseMode);
+		StructureBoundingBox structureboundingbox = StructureBoundingBox.getComponentToAddBoundingBox(x, y, z, 0, 0, 0, 11, 16, 12, coordBaseMode);
 		if (canVillageGoDeeper(structureboundingbox)) {
 			if (StructureComponent.findIntersecting(list, structureboundingbox) == null) {
 				return new ComponentVillageBambooYard(startPiece, par7, random, structureboundingbox, coordBaseMode);
@@ -106,6 +108,18 @@ public class ComponentVillageBambooYard extends StructureVillagePieces.Village i
 		placeBlockAtCurrentPosition(world, block, meta, x, y, z, box);
 	}
 
+	protected void placeWorldGenAt(World world, Random random, int tx, int ty, int tz, StructureBoundingBox bb, WorldGenerator generator)
+    {
+        int x = this.getXWithOffset(tx, tz);
+        int y = this.getYWithOffset(ty);
+        int z = this.getZWithOffset(tx, tz);
+
+        if (bb.isVecInside(x, y, z))
+        {
+            generator.generate(world, random, x, y, z);
+        }
+    }
+
 	public boolean addComponentParts(World world, Random random, StructureBoundingBox box)
 	{
 		if (this.field_143015_k < 0)
@@ -118,16 +132,16 @@ public class ComponentVillageBambooYard extends StructureVillagePieces.Village i
 			}
 
 			// the structure is 1 block lower due to the water layer
-			this.boundingBox.offset(0, this.field_143015_k - this.boundingBox.maxY + 13, 0);
+			this.boundingBox.offset(0, this.field_143015_k - this.boundingBox.maxY + 14, 0);
 		}
 
 		// clear entire bounding box
 		this.fillWithBlocks(world, box, 0, 0, 0, 11, 4, 12, Blocks.air, Blocks.air, false);
 		this.fillWithBlocks(world, box, 0, 0, 0, 11, 0, 12, Blocks.grass, Blocks.grass, false);
+
 		boolean vert = (this.coordBaseMode == 2 || this.coordBaseMode == 0);
 		HashMap<Character, IBlockEntries> map = new HashMap<Character, IBlockEntries>();
 
-		map.put('b', new BlockEntry(GrowthCraftBamboo.bambooShoot, 1));
 		map.put('D', new BlockEntry(GrowthCraftBamboo.bambooDoor, this.getMetadataWithOffset(GrowthCraftBamboo.bambooDoor, 2))); // okay folks, no BIG D jokes here
 		map.put('d', new BlockEntry(GrowthCraftBamboo.bambooDoor, this.getMetadataWithOffset(GrowthCraftBamboo.bambooDoor, 8 | 1))); // top of the door brought forward
 		map.put('p', new BlockEntry(GrowthCraftBamboo.bambooBlock, 0));
@@ -138,11 +152,22 @@ public class ComponentVillageBambooYard extends StructureVillagePieces.Village i
 
 		SchemaToVillage.drawSchema(this, world, random, box, bambooYardSchema, map);
 
+		// This places the bamboo trees to the best of its ability.
+		WorldGenBamboo genBamboo = new WorldGenBamboo(true);
+		placeWorldGenAt(world, random, 4, 1, 4, box, genBamboo);
+		placeWorldGenAt(world, random, 6, 1, 4, box, genBamboo);
+		placeWorldGenAt(world, random, 3, 1, 5, box, genBamboo);
+		placeWorldGenAt(world, random, 7, 1, 5, box, genBamboo);
+		placeWorldGenAt(world, random, 3, 1, 7, box, genBamboo);
+		placeWorldGenAt(world, random, 7, 1, 7, box, genBamboo);
+		placeWorldGenAt(world, random, 4, 1, 8, box, genBamboo);
+		placeWorldGenAt(world, random, 6, 1, 8, box, genBamboo);
+
 		for (int row = 0; row < 12; ++row)
 		{
 			for (int col = 0; col < 11; ++col)
 			{
-				this.clearCurrentPositionBlocksUpwards(world, col, 15, row, box);
+				this.clearCurrentPositionBlocksUpwards(world, col, 16, row, box);
 				this.func_151554_b(world, Blocks.dirt, 0, col, -1, row, box);
 			}
 		}

--- a/src/java/growthcraft/bees/village/ComponentVillageApiarist.java
+++ b/src/java/growthcraft/bees/village/ComponentVillageApiarist.java
@@ -24,16 +24,16 @@ import net.minecraft.world.World;
 public class ComponentVillageApiarist extends StructureVillagePieces.Village implements SchemaToVillage.IVillage
 {
 	// Design by Ar97x, modified by IceDragon (I made the tree levaves a 3x3x3 cube, makes it look neat)
-	static private final String apiaristSchema[][] = {
+	static private final String apiaristExteriorSchema[][] = {
 		{
-			"     88  ",
-			"cxccxppcc",
-			"xpppppppx",
+			"    486  ",
+			"xcccccccx",
 			"cpppppppc",
 			"cpppppppc",
-			"xpppppppx",
-			"ccccccccc",
-			"ddcdddd  ",
+			"cpppppppc",
+			"cpppppppc",
+			"xcccccccx",
+			"ddddddd  ",
 			"ddddddd  ",
 			"ddddddd  ",
 			"ddddddd  ",
@@ -43,115 +43,146 @@ public class ComponentVillageApiarist extends StructureVillagePieces.Village imp
 		},
 		{
 			"         ",
-			"xxxxx  xx",
-			"x       x",
+			"xpppp ppx",
+			"p       p",
 			"B       B",
-			"Y   x-x Y",
-			"x   - - x",
-			"xx xxxxxx",
-			"f, ,,,f  ",
+			"B       B",
+			"p    8  p",
+			"xpp ppppx",
 			"f,,,,,f  ",
 			"f,,,,,f  ",
+			"f,+,+,f  ",
 			"f,,,,,f  ",
-			"ffffxff  ",
+			"ffff ff  ",
 			"         ",
 			"         "
 		},
 		{
 			"         ",
-			"cxggx  xc",
-			"x       x",
-			"g       g",
-			"g    +  g",
-			"x       x",
-			"cx pxggxc",
-			"   +     ",
+			"xpggp ppx",
+			"p       p",
+			"Y       Y",
+			"Y       Y",
+			"p       p",
+			"xpp pgppx",
+			"         ",
 			"         ",
 			"t     t  ",
 			"    H    ",
-			"    x    ",
+			"   t     ",
 			"         ",
 			"         "
 		},
 		{ // the torches for this level are placed manually
 			"888888888",
-			"cxppxppxc",
-			"x       x",
+			"xpppppppx",
+			"p       p",
 			"B       B",
-			"Y   ___ Y",
-			"x   ___ x",
-			"cxppxppxc",
+			"B       B",
+			"p       p",
+			"xpppppppx",
 			"222222222",
 			"         ",
-			"  lllll  ",
-			"  lllll  ",
-			"  llxll  ",
-			"  lllll  ",
-			"  lllll  "
+			"         ",
+			"         ",
+			"         ",
+			"         ",
+			"         "
 		},
 		{
 			"         ",
 			"888888888",
-			"xpppppppx",
+			"ppppppppp",
 			"Yp     pY",
-			"Bp     pB",
-			"xpppppppx",
+			"Yp     pY",
+			"ppppppppp",
 			"222222222",
 			"         ",
 			"         ",
-			"   lll   ",
-			"  lllll  ",
-			"  llxll  ",
-			"  lllll  ",
-			"   lll   "
+			"         ",
+			"         ",
+			"         ",
+			"         ",
+			"         "
 		},
 		{
 			"         ",
 			"         ",
 			"788888889",
-			"4YBYBYBY6",
+			"4BYBYBYB6",
 			"4BYBYBYB6",
 			"122222223",
 			"         ",
 			"         ",
 			"         ",
 			"         ",
-			"    l    ",
-			"   lxl   ",
-			"    l    ",
+			"         ",
+			"         ",
+			"         ",
 			"         "
+		}
+	};
+
+	static private final String apiaristInteriorSchema[][] = {
+		{
+			" 6    4",
+			" 6    K",
+			" 6    K",
+			"p6    4"
 		},
 		{
-			"         ",
-			"         ",
-			"		  ",
-			"		  ",
-			"		  ",
-			"		  ",
-			"         ",
-			"         ",
-			"         ",
-			"         ",
-			"    l    ",
-			"   lxl   ",
-			"    l    ",
-			"         "
+			"      l",
+			"      K",
+			"      K",
+			"      l"
 		},
 		{
-			"         ",
-			"         ",
-			"		  ",
-			"		  ",
-			"		  ",
-			"		  ",
-			"         ",
-			"         ",
-			"         ",
-			"         ",
-			"         ",
-			"    l    ",
-			"         ",
-			"         "
+			" 8    l",
+			" _    K",
+			" _    K",
+			" 2    l"
+		},
+		{
+			"       ",
+			" 2   4 ",
+			" 8   4 ",
+			"       "
+		}
+	};
+
+	// That tree that appears behind the apiary, its a birch tree
+	// Since `x` is already used for Oak in the original schema, I've extracted
+	// here.
+	static private final String apiaristBackyardTreeSchema[][] = {
+		{
+			"   ",
+			" x ",
+			"   ",
+		},
+		{ // bee hive appears on this level
+			"   ",
+			" x ",
+			"   ",
+		},
+		{
+			"lll",
+			"lxl",
+			"lll",
+		},
+		{
+			"lll",
+			"lxl",
+			"lll",
+		},
+		{
+			" l ",
+			"lxl",
+			" l ",
+		},
+		{
+			"   ",
+			" l ",
+			"   ",
 		}
 	};
 
@@ -204,14 +235,21 @@ public class ComponentVillageApiarist extends StructureVillagePieces.Village imp
 		this.fillWithBlocks(world, box, 0, 0, 0, 9, 8, 14, Blocks.air, Blocks.air, false);
 
 		HashMap<Character, IBlockEntries> map = new HashMap<Character, IBlockEntries>();
-		boolean vert = (this.coordBaseMode == 2 || this.coordBaseMode == 0);
+
+		// Plop down the tree first
+		map.put('x', new BlockEntry(Blocks.log, 2));
+		map.put('l', new BlockEntry(Blocks.leaves, 2));
+
+		SchemaToVillage.drawSchema(this, world, random, box, apiaristBackyardTreeSchema, map, 3, 1, 10);
+
+		map.clear();
 
 		map.put('c', new BlockEntry(Blocks.cobblestone));
-		map.put('d', new BlockEntry(Blocks.grass, 0));
+		map.put('d', new BlockEntry(Blocks.grass));
 		map.put('p', new BlockEntry(Blocks.planks));
 		map.put('x', new BlockEntry(Blocks.log));
 		map.put('l', new BlockEntry(Blocks.leaves));
-		map.put('g', new BlockEntry(Blocks.stained_glass, 15));
+		map.put('g', new BlockEntry(Blocks.glass_pane));
 
 		map.put('f', new BlockEntry(Blocks.fence));
 		map.put('-', new BlockEntry(Blocks.wooden_slab, 8)); // high slab
@@ -236,35 +274,77 @@ public class ComponentVillageApiarist extends StructureVillagePieces.Village imp
 
 		map.put('t', new BlockEntry(Blocks.torch));
 
-		map.put('Y', new BlockEntry(Blocks.wool, 4));
-		map.put('B', new BlockEntry(Blocks.wool, 15));
+		map.put('Y', new BlockEntry(Blocks.planks, 2));
+		map.put('B', new BlockEntry(Blocks.planks, 1));
 
-		map.put('H', new BlockEntry(GrowthCraftBees.beeHive, 0));
+		map.put('H', new BlockEntry(GrowthCraftBees.beeHive, this.getMetadataWithOffset(GrowthCraftBees.beeHive, 3)));
 		map.put('+', new BlockEntry(GrowthCraftBees.beeBox, this.getMetadataWithOffset(GrowthCraftBees.beeBox, 2)));
 
-		SchemaToVillage.drawSchema(this, world, random, box, apiaristSchema, map, 0, 0, 0);
+		SchemaToVillage.drawSchema(this, world, random, box, apiaristExteriorSchema, map, 0, 0, 0);
 
-		this.placeBlockAtCurrentPosition(world, Blocks.torch, 0, 1, 3, 2, box);
-		this.placeBlockAtCurrentPosition(world, Blocks.torch, 0, 7, 3, 2, box);
-		this.placeBlockAtCurrentPosition(world, Blocks.torch, 0, 1, 3, 5, box);
-		this.placeBlockAtCurrentPosition(world, Blocks.torch, 0, 7, 3, 5, box);
+		// Get ready to recycle for interior design
+		map.clear();
 
-		this.placeDoorAtCurrentPosition(world, box, random, 2, 1, 6, this.getMetadataWithOffset(Blocks.wooden_door, 1));
+		map.put('p', new BlockEntry(Blocks.planks));
+
+		// inverted stairs for decorating interior
+		map.put('1', new BlockEntry(Blocks.oak_stairs, this.getMetadataWithOffset(Blocks.oak_stairs, 2) | 4));
+		map.put('2', new BlockEntry(Blocks.oak_stairs, this.getMetadataWithOffset(Blocks.oak_stairs, 2) | 4));
+		map.put('3', new BlockEntry(Blocks.oak_stairs, this.getMetadataWithOffset(Blocks.oak_stairs, 2) | 4));
+
+		map.put('4', new BlockEntry(Blocks.oak_stairs, this.getMetadataWithOffset(Blocks.oak_stairs, 0) | 4));
+		map.put('6', new BlockEntry(Blocks.oak_stairs, this.getMetadataWithOffset(Blocks.oak_stairs, 1) | 4));
+
+		map.put('7', new BlockEntry(Blocks.oak_stairs, this.getMetadataWithOffset(Blocks.oak_stairs, 3) | 4));
+		map.put('8', new BlockEntry(Blocks.oak_stairs, this.getMetadataWithOffset(Blocks.oak_stairs, 3) | 4));
+		map.put('9', new BlockEntry(Blocks.oak_stairs, this.getMetadataWithOffset(Blocks.oak_stairs, 3) | 4));
+
+		map.put('_', new BlockEntry(Blocks.wooden_slab, 0));
+
+		map.put('K', new BlockEntry(Blocks.bookshelf, 0));
+
+		// metadata here is (1(spruce leaves) | 4(no decay))
+		map.put('l', new BlockEntry(Blocks.leaves, 1 | 4));
+
+		SchemaToVillage.drawSchema(this, world, random, box, apiaristInteriorSchema, map, 1, 1, 2);
+
+		// Place torches
+		this.placeBlockAtCurrentPosition(world, Blocks.torch, 0, 5, 3, 2, box);
+		this.placeBlockAtCurrentPosition(world, Blocks.torch, 0, 4, 3, 5, box);
+
+		/*
+			TODO:
+				place signs beside stairs to form a chair -
+				If you happen to be a sign rotation expert, PLEASE DO FIX THIS.
+		 */
+		//this.placeBlockAtCurrentPosition(world, Blocks.wall_sign, 2, 4, 1, 5, box);
+		//this.placeBlockAtCurrentPosition(world, Blocks.wall_sign, 2, 6, 1, 5, box);
+
+		// Drop in the front door
 		this.placeDoorAtCurrentPosition(world, box, random, 5, 1, 1, this.getMetadataWithOffset(Blocks.wooden_door, 1));
-		this.placeDoorAtCurrentPosition(world, box, random, 6, 1, 1, this.getMetadataWithOffset(Blocks.wooden_door, 1));
+		// Drop in the back door
+		this.placeDoorAtCurrentPosition(world, box, random, 3, 1, 6, this.getMetadataWithOffset(Blocks.wooden_door, 1));
 
-		this.generateStructureChestContents(world, box, random, 1, 1, 2, apiaristChestContents, 3 + random.nextInt(6));
+		// Slap that nicely placed flower pot on the counter
+		this.placeBlockAtCurrentPosition(world, Blocks.flower_pot, 3, 2, 2, 2, box);
 
+		// Shove a chest behind the counter, filled with goodies
+		this.generateStructureChestContents(world, box, random, 1, 2, 5, apiaristChestContents, 3 + random.nextInt(6));
+
+		// Fix some structural madness, like buildings spawning in the air and
+		// floating on a thin layer of dirt/cobblestone
 		for (int row = 0; row < 14; ++row)
 		{
 			for (int col = 0; col < 9; ++col)
 			{
 				this.clearCurrentPositionBlocksUpwards(world, col, 8, row, box);
-				this.func_151554_b(world, Blocks.dirt, 0, col, -1, row, box);
+				this.func_151554_b(world, Blocks.cobblestone, 0, col, -1, row, box);
 			}
 		}
 
-		this.spawnVillagers(world, box, 3, 2, 3, 1);
+		// Trap the villager behind the counter, so he shall forever sells us
+		// apiary items... Poor guy.
+		this.spawnVillagers(world, box, 1, 2, 3, 1);
 		return true;
 	}
 

--- a/src/java/growthcraft/bees/village/ComponentVillageApiarist.java
+++ b/src/java/growthcraft/bees/village/ComponentVillageApiarist.java
@@ -162,6 +162,7 @@ public class ComponentVillageApiarist extends StructureVillagePieces.Village imp
 		new WeightedRandomChestContent(Item.getItemFromBlock(GrowthCraftBees.beeBox), 0, 1, 2, 5)
 	};
 
+	public ComponentVillageApiarist() {} // DO NOT REMOVE
 	public ComponentVillageApiarist(Start startPiece, int par2, Random random, StructureBoundingBox boundingBox, int coordBaseMode)
 	{
 		super(startPiece, par2);

--- a/src/java/growthcraft/bees/village/ComponentVillageApiarist.java
+++ b/src/java/growthcraft/bees/village/ComponentVillageApiarist.java
@@ -172,7 +172,7 @@ public class ComponentVillageApiarist extends StructureVillagePieces.Village imp
 
 	public static ComponentVillageApiarist buildComponent(Start startPiece, List list, Random random, int x, int y, int z, int coordBaseMode, int par7)
 	{
-		StructureBoundingBox structureboundingbox = StructureBoundingBox.getComponentToAddBoundingBox(x, y, z, 0, 0, 0, 12, 10, 15, coordBaseMode);
+		StructureBoundingBox structureboundingbox = StructureBoundingBox.getComponentToAddBoundingBox(x, y, z, 0, 0, 0, 9, 8, 14, coordBaseMode);
 		if (canVillageGoDeeper(structureboundingbox)) {
 			if (StructureComponent.findIntersecting(list, structureboundingbox) == null) {
 				return new ComponentVillageApiarist(startPiece, par7, random, structureboundingbox, coordBaseMode);
@@ -197,13 +197,11 @@ public class ComponentVillageApiarist extends StructureVillagePieces.Village imp
 				return true;
 			}
 
-			this.boundingBox.offset(0, this.field_143015_k - this.boundingBox.maxY + 8, 0);
+			this.boundingBox.offset(0, this.field_143015_k - this.boundingBox.maxY + 7, 0);
 		}
 
 		// clear entire bounding box
-		this.fillWithBlocks(world, box, 0, 0, 0, 12, 9, 15, Blocks.air, Blocks.air, false);
-		// replace the base layer with grass
-		this.fillWithBlocks(world, box, 0, 0, 0, 12, 0, 15, Blocks.grass, Blocks.grass, false);
+		this.fillWithBlocks(world, box, 0, 0, 0, 9, 8, 14, Blocks.air, Blocks.air, false);
 
 		HashMap<Character, IBlockEntries> map = new HashMap<Character, IBlockEntries>();
 		boolean vert = (this.coordBaseMode == 2 || this.coordBaseMode == 0);
@@ -244,18 +242,27 @@ public class ComponentVillageApiarist extends StructureVillagePieces.Village imp
 		map.put('H', new BlockEntry(GrowthCraftBees.beeHive, 0));
 		map.put('+', new BlockEntry(GrowthCraftBees.beeBox, this.getMetadataWithOffset(GrowthCraftBees.beeBox, 2)));
 
-		SchemaToVillage.drawSchema(this, world, random, box, apiaristSchema, map, 0, 1, 0);
+		SchemaToVillage.drawSchema(this, world, random, box, apiaristSchema, map, 0, 0, 0);
 
-		this.placeBlockAtCurrentPosition(world, Blocks.torch, 0, 1, 4, 2, box);
-		this.placeBlockAtCurrentPosition(world, Blocks.torch, 0, 7, 4, 2, box);
-		this.placeBlockAtCurrentPosition(world, Blocks.torch, 0, 1, 4, 5, box);
-		this.placeBlockAtCurrentPosition(world, Blocks.torch, 0, 7, 4, 5, box);
+		this.placeBlockAtCurrentPosition(world, Blocks.torch, 0, 1, 3, 2, box);
+		this.placeBlockAtCurrentPosition(world, Blocks.torch, 0, 7, 3, 2, box);
+		this.placeBlockAtCurrentPosition(world, Blocks.torch, 0, 1, 3, 5, box);
+		this.placeBlockAtCurrentPosition(world, Blocks.torch, 0, 7, 3, 5, box);
 
-		this.placeDoorAtCurrentPosition(world, box, random, 2, 2, 6, this.getMetadataWithOffset(Blocks.wooden_door, 1));
-		this.placeDoorAtCurrentPosition(world, box, random, 5, 2, 1, this.getMetadataWithOffset(Blocks.wooden_door, 1));
-		this.placeDoorAtCurrentPosition(world, box, random, 6, 2, 1, this.getMetadataWithOffset(Blocks.wooden_door, 1));
+		this.placeDoorAtCurrentPosition(world, box, random, 2, 1, 6, this.getMetadataWithOffset(Blocks.wooden_door, 1));
+		this.placeDoorAtCurrentPosition(world, box, random, 5, 1, 1, this.getMetadataWithOffset(Blocks.wooden_door, 1));
+		this.placeDoorAtCurrentPosition(world, box, random, 6, 1, 1, this.getMetadataWithOffset(Blocks.wooden_door, 1));
 
-		this.generateStructureChestContents(world, box, random, 1, 2, 2, apiaristChestContents, 3 + random.nextInt(6));
+		this.generateStructureChestContents(world, box, random, 1, 1, 2, apiaristChestContents, 3 + random.nextInt(6));
+
+		for (int row = 0; row < 14; ++row)
+		{
+			for (int col = 0; col < 9; ++col)
+			{
+				this.clearCurrentPositionBlocksUpwards(world, col, 8, row, box);
+				this.func_151554_b(world, Blocks.dirt, 0, col, -1, row, box);
+			}
+		}
 
 		this.spawnVillagers(world, box, 3, 2, 3, 1);
 		return true;

--- a/src/java/growthcraft/bees/village/ComponentVillageApiarist.java
+++ b/src/java/growthcraft/bees/village/ComponentVillageApiarist.java
@@ -196,8 +196,13 @@ public class ComponentVillageApiarist extends StructureVillagePieces.Village imp
 				return true;
 			}
 
-			this.boundingBox.offset(0, this.field_143015_k - this.boundingBox.maxY + 10 - 1, 0);
+			this.boundingBox.offset(0, this.field_143015_k - this.boundingBox.maxY + 8, 0);
 		}
+
+		// clear entire bounding box
+		this.fillWithBlocks(world, box, 0, 0, 0, 12, 9, 15, Blocks.air, Blocks.air, false);
+		// replace the base layer with grass
+		this.fillWithBlocks(world, box, 0, 0, 0, 12, 0, 15, Blocks.grass, Blocks.grass, false);
 
 		HashMap<Character, IBlockEntries> map = new HashMap<Character, IBlockEntries>();
 		boolean vert = (this.coordBaseMode == 2 || this.coordBaseMode == 0);
@@ -238,20 +243,20 @@ public class ComponentVillageApiarist extends StructureVillagePieces.Village imp
 		map.put('H', new BlockEntry(GrowthCraftBees.beeHive, 0));
 		map.put('+', new BlockEntry(GrowthCraftBees.beeBox, this.getMetadataWithOffset(GrowthCraftBees.beeBox, 2)));
 
-		SchemaToVillage.drawSchema(this, world, random, box, apiaristSchema, map);
+		SchemaToVillage.drawSchema(this, world, random, box, apiaristSchema, map, 0, 1, 0);
 
-		this.placeBlockAtCurrentPosition(world, Blocks.torch, 0, 1, 3, 2, box);
-		this.placeBlockAtCurrentPosition(world, Blocks.torch, 0, 7, 3, 2, box);
-		this.placeBlockAtCurrentPosition(world, Blocks.torch, 0, 1, 3, 5, box);
-		this.placeBlockAtCurrentPosition(world, Blocks.torch, 0, 7, 3, 5, box);
+		this.placeBlockAtCurrentPosition(world, Blocks.torch, 0, 1, 4, 2, box);
+		this.placeBlockAtCurrentPosition(world, Blocks.torch, 0, 7, 4, 2, box);
+		this.placeBlockAtCurrentPosition(world, Blocks.torch, 0, 1, 4, 5, box);
+		this.placeBlockAtCurrentPosition(world, Blocks.torch, 0, 7, 4, 5, box);
 
-		this.placeDoorAtCurrentPosition(world, box, random, 2, 1, 6, this.getMetadataWithOffset(Blocks.wooden_door, 1));
-		this.placeDoorAtCurrentPosition(world, box, random, 5, 1, 1, this.getMetadataWithOffset(Blocks.wooden_door, 1));
-		this.placeDoorAtCurrentPosition(world, box, random, 6, 1, 1, this.getMetadataWithOffset(Blocks.wooden_door, 1));
+		this.placeDoorAtCurrentPosition(world, box, random, 2, 2, 6, this.getMetadataWithOffset(Blocks.wooden_door, 1));
+		this.placeDoorAtCurrentPosition(world, box, random, 5, 2, 1, this.getMetadataWithOffset(Blocks.wooden_door, 1));
+		this.placeDoorAtCurrentPosition(world, box, random, 6, 2, 1, this.getMetadataWithOffset(Blocks.wooden_door, 1));
 
-		this.generateStructureChestContents(world, box, random, 1, 1, 2, apiaristChestContents, 3 + random.nextInt(6));
+		this.generateStructureChestContents(world, box, random, 1, 2, 2, apiaristChestContents, 3 + random.nextInt(6));
 
-		this.spawnVillagers(world, box, 3, 1, 3, 1);
+		this.spawnVillagers(world, box, 3, 2, 3, 1);
 		return true;
 	}
 

--- a/src/java/growthcraft/core/utils/SchemaToVillage.java
+++ b/src/java/growthcraft/core/utils/SchemaToVillage.java
@@ -69,33 +69,45 @@ public class SchemaToVillage
 		}
 	}
 
-	public static void drawSchema(IVillage village, World world, Random random, StructureBoundingBox box, String schema[][], Map<Character, IBlockEntries> map)
+	public static void drawSchema(IVillage village, World world, Random random, StructureBoundingBox box, String schema[][], Map<Character, IBlockEntries> map, int offx, int offy, int offz)
 	{
-		for (int z = 0; z < schema.length; ++z)
+		// loop by schema layer
+		for (int y = 0; y < schema.length; ++y)
 		{
-			String layer[] = schema[z];
-			for (int y = 0; y < layer.length; ++y)
+			String layer[] = schema[y];
+			// then loop by schema layer-row
+			for (int z = 0; z < layer.length; ++z)
 			{
-				String row = layer[y];
+				String row = layer[z];
+				// finally loop by schema layer-row-cell
 				for (int x = 0; x < row.length(); ++x)
 				{
 					int meta = 0;
 					Block block = null;
 					IBlockEntries entries = map.get(row.charAt(x));
+					// look out for null entries, though by right we should
+					// warn about these.
 					if (entries != null)
 					{
 						BlockEntry entry = entries.getBlockEntry(random);
+						// a null entry is possible, for "Ignore the this block"
 						if (entry != null)
 						{
 							block = entry.getBlock();
 							meta = entry.getMetadata();
 						}
 					}
+					// null blocks are not placed
 					if (block != null) {
-						village.placeBlockAtCurrentPositionPub(world, block, meta, x, z, y, box);
+						village.placeBlockAtCurrentPositionPub(world, block, meta, offx + x, offy + y, offz + z, box);
 					}
 				}
 			}
 		}
+	}
+
+	public static void drawSchema(IVillage village, World world, Random random, StructureBoundingBox box, String schema[][], Map<Character, IBlockEntries> map)
+	{
+		drawSchema(village, world, random, box, schema, map, 0, 0, 0);
 	}
 }

--- a/src/java/growthcraft/rice/village/ComponentVillageRiceField.java
+++ b/src/java/growthcraft/rice/village/ComponentVillageRiceField.java
@@ -81,6 +81,7 @@ public class ComponentVillageRiceField extends StructureVillagePieces.Village im
 		}
 	};
 
+	public ComponentVillageRiceField() {} // DO NOT REMOVE
 	public ComponentVillageRiceField(Start startPiece, int par2, Random random, StructureBoundingBox boundingBox, int coordBaseMode)
 	{
 		super(startPiece, par2);

--- a/src/java/growthcraft/rice/village/ComponentVillageRiceField.java
+++ b/src/java/growthcraft/rice/village/ComponentVillageRiceField.java
@@ -90,7 +90,7 @@ public class ComponentVillageRiceField extends StructureVillagePieces.Village im
 
 	public static ComponentVillageRiceField buildComponent(Start startPiece, List list, Random random, int x, int y, int z, int coordBaseMode, int par7)
 	{
-		StructureBoundingBox structureboundingbox = StructureBoundingBox.getComponentToAddBoundingBox(x, y, z, 0, 0, 0, 13, 4, 13, coordBaseMode);
+		StructureBoundingBox structureboundingbox = StructureBoundingBox.getComponentToAddBoundingBox(x, y, z, 0, 0, 0, 13, 6, 13, coordBaseMode);
 		if (canVillageGoDeeper(structureboundingbox)) {
 			if (StructureComponent.findIntersecting(list, structureboundingbox) == null) {
 				return new ComponentVillageRiceField(startPiece, par7, random, structureboundingbox, coordBaseMode);
@@ -115,11 +115,17 @@ public class ComponentVillageRiceField extends StructureVillagePieces.Village im
 				return true;
 			}
 
-			this.boundingBox.offset(0, this.field_143015_k - this.boundingBox.maxY + 4 - 1, 0);
+			this.boundingBox.offset(0, this.field_143015_k - this.boundingBox.maxY + 4, 0);
 		}
+
+		// clear entire bounding box
+		this.fillWithBlocks(world, box, 0, 0, 0, 13, 4, 13, Blocks.air, Blocks.air, false);
+		// replace the base layer with grass
+		this.fillWithBlocks(world, box, 0, 0, 0, 13, 0, 13, Blocks.grass, Blocks.grass, false);
 
 		boolean vert = (this.coordBaseMode == 2 || this.coordBaseMode == 0);
 		HashMap<Character, IBlockEntries> map = new HashMap<Character, IBlockEntries>();
+
 		map.put('-', new BlockEntry(Blocks.log, vert ? 4 : 8));
 		map.put('f', new BlockEntry(Blocks.fence));
 		map.put('g', new BlockEntry(Blocks.fence_gate, this.getMetadataWithOffset(Blocks.fence_gate, 0)));
@@ -131,7 +137,7 @@ public class ComponentVillageRiceField extends StructureVillagePieces.Village im
 		map.put('|', new BlockEntry(Blocks.log, vert ? 8 : 4));
 		map.put('~', new BlockEntry(Blocks.water));
 
-		SchemaToVillage.drawSchema(this, world, random, box, riceFieldSchema, map);
+		SchemaToVillage.drawSchema(this, world, random, box, riceFieldSchema, map, 0, 1, 0);
 		return true;
 	}
 }

--- a/src/java/growthcraft/rice/village/ComponentVillageRiceField.java
+++ b/src/java/growthcraft/rice/village/ComponentVillageRiceField.java
@@ -91,7 +91,7 @@ public class ComponentVillageRiceField extends StructureVillagePieces.Village im
 
 	public static ComponentVillageRiceField buildComponent(Start startPiece, List list, Random random, int x, int y, int z, int coordBaseMode, int par7)
 	{
-		StructureBoundingBox structureboundingbox = StructureBoundingBox.getComponentToAddBoundingBox(x, y, z, 0, 0, 0, 13, 6, 13, coordBaseMode);
+		StructureBoundingBox structureboundingbox = StructureBoundingBox.getComponentToAddBoundingBox(x, y, z, 0, 0, 0, 11, 4, 12, coordBaseMode);
 		if (canVillageGoDeeper(structureboundingbox)) {
 			if (StructureComponent.findIntersecting(list, structureboundingbox) == null) {
 				return new ComponentVillageRiceField(startPiece, par7, random, structureboundingbox, coordBaseMode);
@@ -116,13 +116,11 @@ public class ComponentVillageRiceField extends StructureVillagePieces.Village im
 				return true;
 			}
 
-			this.boundingBox.offset(0, this.field_143015_k - this.boundingBox.maxY + 4, 0);
+			this.boundingBox.offset(0, this.field_143015_k - this.boundingBox.maxY + 3, 0);
 		}
 
 		// clear entire bounding box
-		this.fillWithBlocks(world, box, 0, 0, 0, 13, 4, 13, Blocks.air, Blocks.air, false);
-		// replace the base layer with grass
-		this.fillWithBlocks(world, box, 0, 0, 0, 13, 0, 13, Blocks.grass, Blocks.grass, false);
+		this.fillWithBlocks(world, box, 0, 0, 0, 11, 4, 12, Blocks.air, Blocks.air, false);
 
 		boolean vert = (this.coordBaseMode == 2 || this.coordBaseMode == 0);
 		HashMap<Character, IBlockEntries> map = new HashMap<Character, IBlockEntries>();
@@ -138,7 +136,17 @@ public class ComponentVillageRiceField extends StructureVillagePieces.Village im
 		map.put('|', new BlockEntry(Blocks.log, vert ? 8 : 4));
 		map.put('~', new BlockEntry(Blocks.water));
 
-		SchemaToVillage.drawSchema(this, world, random, box, riceFieldSchema, map, 0, 1, 0);
+		SchemaToVillage.drawSchema(this, world, random, box, riceFieldSchema, map, 0, 0, 0);
+
+		for (int row = 0; row < 12; ++row)
+		{
+			for (int col = 0; col < 11; ++col)
+			{
+				this.clearCurrentPositionBlocksUpwards(world, col, 4, row, box);
+				this.func_151554_b(world, Blocks.dirt, 0, col, -1, row, box);
+			}
+		}
+
 		return true;
 	}
 }

--- a/src/java/growthcraft/rice/village/ComponentVillageRiceField.java
+++ b/src/java/growthcraft/rice/village/ComponentVillageRiceField.java
@@ -122,7 +122,7 @@ public class ComponentVillageRiceField extends StructureVillagePieces.Village im
 		// clear entire bounding box
 		this.fillWithBlocks(world, box, 0, 0, 0, 11, 4, 12, Blocks.air, Blocks.air, false);
 
-		boolean vert = (this.coordBaseMode == 2 || this.coordBaseMode == 0);
+		boolean vert = (this.coordBaseMode == 2 || this.coordBaseMode == 3);
 		HashMap<Character, IBlockEntries> map = new HashMap<Character, IBlockEntries>();
 
 		map.put('-', new BlockEntry(Blocks.log, vert ? 4 : 8));


### PR DESCRIPTION
This should fix village structures spawning with invalid blocks in them.

Overall the changes are: adding a overload of `drawSchema` that takes an offset and all structures using the `SchemaToVillage` format fill their base layer with grass, as well as clearing the bounding box with air blocks.
## Builds:
### Latest

[Build3](https://dl.dropboxusercontent.com/u/72618186/minecraft/mods/growthcraft/2.2.2/growthcraft-2.2.2-complete_with_village_fixes-build3.jar)
### Old

[Build2](https://dl.dropboxusercontent.com/u/72618186/minecraft/mods/growthcraft/2.2.2/growthcraft-2.2.2-complete_with_village_fixes-build2.jar)
[Build1](https://dl.dropboxusercontent.com/u/72618186/minecraft/mods/growthcraft/2.2.2/growthcraft-2.2.2-complete_with_village_fixes-build1.jar)
