### PR TITLE
Handle some bogged vine drops

### DIFF
--- a/src/java/growthcraft/api/core/CoreRegistry.java
+++ b/src/java/growthcraft/api/core/CoreRegistry.java
@@ -7,13 +7,32 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.util.WeightedRandom;
 import net.minecraft.world.World;
 
+import org.apache.logging.log4j.Level;
+import cpw.mods.fml.common.FMLLog;
+
 public class CoreRegistry
 {
+	class VineEntry extends WeightedRandom.Item
+	{
+		public final ItemStack vine;
+		public VineEntry(ItemStack vine, int weight)
+		{
+			super(weight);
+			this.vine = vine;
+		}
+	}
 	/**
 	 * Gwafu:
 	 *
 	 * Yes, it's the same functons/methods as Forge's tall grass hook.
 	 */
+
+	/**
+	 * @return vine drop list
+	 */
+	public List<VineEntry> getList(){ return vineList; }
+
+	private final List<VineEntry> vineList = new ArrayList<VineEntry>();
 
 	private static final CoreRegistry instance = new CoreRegistry();
 	public static final CoreRegistry instance()
@@ -33,33 +52,37 @@ public class CoreRegistry
 	 */
 	public void addVineDrop(ItemStack item, int weight)
 	{
+		if (weight <= 0)
+		{
+			FMLLog.log("Growthcraft", Level.WARN,
+			 	"RARITY/WEIGHT WAS SET TO 0 FOR ITEM: " +
+			 	item.getUnlocalizedName() +
+			 	", THE WORLD IS CRUMBLING, WHAT HAVE YOU DONE ~ IceDragon. Go set it to 1 or something.");
+			weight = 1;
+		}
 		this.vineList.add(new VineEntry(item, weight));
 	}
 
 	/**
-	 * STUFF
+	 * @return true if their are any vine drops, false otherwise
 	 */
-	class VineEntry extends WeightedRandom.Item
+	public boolean hasVineDrops()
 	{
-		public final ItemStack vine;
-		public VineEntry(ItemStack vine, int weight)
-		{
-			super(weight);
-			this.vine = vine;
-		}
+		return !getList().isEmpty();
 	}
 
-	public ItemStack getVineList(World world)
+	/**
+	 * @param world - The world
+	 * @return itemstack or null
+	 */
+	public ItemStack getVineDropItem(World world)
 	{
-		VineEntry entry = (VineEntry)WeightedRandom.getRandomItem(world.rand, this.vineList);
-		if (entry == null || entry.vine == null)
-		{
-			return null;
-		}
+		final List<VineEntry> vineEntries = getList();
+		if (vineEntries.isEmpty()) return null;
+
+		VineEntry entry = (VineEntry)WeightedRandom.getRandomItem(world.rand, vineEntries);
+		if (entry == null || entry.vine == null) return null;
+
 		return entry.vine.copy();
 	}
-
-	public List<VineEntry> getList(){ return vineList; }
-
-	final List<VineEntry> vineList = new ArrayList<VineEntry>();
 }

--- a/src/java/growthcraft/core/event/HarvestDropsEventCore.java
+++ b/src/java/growthcraft/core/event/HarvestDropsEventCore.java
@@ -32,13 +32,13 @@ public class HarvestDropsEventCore
 
 	private void doDrops(HarvestDropsEvent event)
 	{
-		if (!CoreRegistry.instance().getList().isEmpty())
+		if (CoreRegistry.instance().hasVineDrops())
 		{
 			if (new Random().nextInt(r) == 0)
 			{
 				event.drops.clear();
 				event.dropChance = 1.0F;
-				ItemStack stack = CoreRegistry.instance().getVineList(event.world);
+				ItemStack stack = CoreRegistry.instance().getVineDropItem(event.world);
 				if (stack != null)
 				{
 					event.drops.add(new ItemStack(stack.getItem(), event.world.rand.nextInt(stack.stackSize) + 1));


### PR DESCRIPTION
Should address #93 
WeightedRandom doesn't like 0 weights, and doesn't give nice error messages either :(
## What does this do?

Patches weights set to 0 (they are set to 1) for vine drops, therefore bypassing the weighted random issue. If patched, a ranty message is printed to the console.
## Builds
### Latest

[Build 2](https://dl.dropboxusercontent.com/u/72618186/minecraft/mods/growthcraft/2.2.2/growthcraft-1.7.10-2.2.2-complete_vine-break-fix-build2.jar)
### Old

[Build 1](https://dl.dropboxusercontent.com/u/72618186/minecraft/mods/growthcraft/2.2.2/growthcraft-1.7.10-2.2.2-complete_vine-break-fix-build1.jar)
[Build 0](https://dl.dropboxusercontent.com/u/72618186/minecraft/mods/growthcraft/2.2.2/growthcraft-1.7.10-2.2.2-complete_vine-break-fix-build0.jar)
