### PR TITLE
Consistent right clicks

### DIFF
--- a/src/java/growthcraft/apples/block/BlockApple.java
+++ b/src/java/growthcraft/apples/block/BlockApple.java
@@ -15,6 +15,7 @@ import net.minecraft.block.Block;
 import net.minecraft.block.IGrowable;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
+import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.init.Items;
 import net.minecraft.item.Item;
@@ -80,6 +81,19 @@ public class BlockApple extends Block implements IGrowable, ICropDataProvider
 		incrementGrowth(world, x, y, z, world.getBlockMetadata(x, y, z));
 	}
 
+	/**
+	 * Drops the block as an item and replaces it with air
+	 * @param world - world to drop in
+	 * @param x - x Coord
+	 * @param y - y Coord
+	 * @param z - z Coord
+	 */
+	public void fellBlockAsItem(World world, int x, int y, int z)
+	{
+		this.dropBlockAsItem(world, x, y, z, world.getBlockMetadata(x, y, z), 0);
+		world.setBlockToAir(x, y, z);
+	}
+
 	/************
 	 * TICK
 	 ************/
@@ -107,8 +121,7 @@ public class BlockApple extends Block implements IGrowable, ICropDataProvider
 				}
 				else if (meta >= 2 && this.dropRipeApples && world.rand.nextInt(this.dropChance) == 0)
 				{
-					this.dropBlockAsItem(world, x, y, z, new ItemStack(Items.apple));
-					world.setBlockToAir(x, y, z);
+					fellBlockAsItem(world, x, y, z);
 				}
 			}
 		}
@@ -118,12 +131,21 @@ public class BlockApple extends Block implements IGrowable, ICropDataProvider
 	 * TRIGGERS
 	 ************/
 	@Override
+	public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int dir, float par7, float par8, float par9)
+	{
+		if (!world.isRemote)
+		{
+			fellBlockAsItem(world, x, y, z);
+		}
+		return true;
+	}
+
+	@Override
 	public void onNeighborBlockChange(World world, int x, int y, int z, Block block)
 	{
 		if (!this.canBlockStay(world, x, y, z))
 		{
-			this.dropBlockAsItem(world, x, y, z, world.getBlockMetadata(x, y, z), 0);
-			world.setBlock(x, y, z, Blocks.air, 0, 2);
+			fellBlockAsItem(world, x, y, z);
 		}
 	}
 

--- a/src/java/growthcraft/core/utils/BlockFlags.java
+++ b/src/java/growthcraft/core/utils/BlockFlags.java
@@ -1,0 +1,17 @@
+package growthcraft.core.utils;
+
+/**
+ * Constant space for block flags, use these instead of magic numbers
+ */
+public final class BlockFlags
+{
+	// Cause the block to update
+	public static final int BLOCK_UPDATE = 1;
+	// Send change to clients
+	public static final int SEND_TO_CLIENT = 2;
+	// Stop the block from re-rendering
+	public static final int SUPRESS_RENDER = 4;
+
+	public static final int UPDATE_CLIENT = BLOCK_UPDATE | SEND_TO_CLIENT;
+	public static final int ALL = UPDATE_CLIENT | SUPRESS_RENDER;
+}

--- a/src/java/growthcraft/core/utils/ConstID.java
+++ b/src/java/growthcraft/core/utils/ConstID.java
@@ -2,7 +2,7 @@ package growthcraft.core.utils;
 
 // Place any "Magic Numbers" in this class, so we don't have to play the
 // guessing game while reading
-public class ConstID
+public final class ConstID
 {
 	// Used for handling non existant fluids
 	public static final int NO_FLUID = -1;

--- a/src/java/growthcraft/grapes/block/BlockGrapeBlock.java
+++ b/src/java/growthcraft/grapes/block/BlockGrapeBlock.java
@@ -2,6 +2,7 @@ package growthcraft.grapes.block;
 
 import java.util.Random;
 
+import growthcraft.core.utils.BlockFlags;
 import growthcraft.grapes.GrowthCraftGrapes;
 import growthcraft.grapes.renderer.RenderGrape;
 
@@ -33,6 +34,19 @@ public class BlockGrapeBlock extends Block
 		this.setBlockBounds(0.1875F, 0.5F, 0.1875F, 0.8125F, 1.0F, 0.8125F);
 	}
 
+	/**
+	 * Drops the block as an item and replaces it with air
+	 * @param world - world to drop in
+	 * @param x - x Coord
+	 * @param y - y Coord
+	 * @param z - z Coord
+	 */
+	public void fellBlockAsItem(World world, int x, int y, int z)
+	{
+		this.dropBlockAsItem(world, x, y, z, world.getBlockMetadata(x, y, z), 0);
+		world.setBlockToAir(x, y, z);
+	}
+
 	/************
 	 * TICK
 	 ************/
@@ -41,8 +55,7 @@ public class BlockGrapeBlock extends Block
 	{
 		if (!this.canBlockStay(world, x, y, z))
 		{
-			this.dropBlockAsItem(world, x, y, z, world.getBlockMetadata(x, y, z), 0);
-			world.setBlock(x, y, z, Blocks.air, 0, 3);
+			fellBlockAsItem(world, x, y, z);
 		}
 	}
 
@@ -50,12 +63,21 @@ public class BlockGrapeBlock extends Block
 	 * TRIGGERS
 	 ************/
 	@Override
+	public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int dir, float par7, float par8, float par9)
+	{
+		if (!world.isRemote)
+		{
+			fellBlockAsItem(world, x, y, z);
+		}
+		return true;
+	}
+
+	@Override
 	public void onNeighborBlockChange(World world, int x, int y, int z, Block par5)
 	{
 		if (!this.canBlockStay(world, x, y, z))
 		{
-			this.dropBlockAsItem(world, x, y, z, world.getBlockMetadata(x, y, z), 0);
-			world.setBlock(x, y, z, Blocks.air, 0, 3);
+			fellBlockAsItem(world, x, y, z);
 		}
 	}
 

--- a/src/java/growthcraft/grapes/event/BonemealEventGrapes.java
+++ b/src/java/growthcraft/grapes/event/BonemealEventGrapes.java
@@ -1,6 +1,7 @@
 package growthcraft.grapes.event;
 
 import growthcraft.core.GrowthCraftCore;
+import growthcraft.core.utils.BlockFlags;
 import growthcraft.grapes.GrowthCraftGrapes;
 import growthcraft.grapes.block.BlockGrapeVine0;
 import growthcraft.grapes.block.BlockGrapeVine1;
@@ -13,77 +14,98 @@ import net.minecraftforge.event.entity.player.BonemealEvent;
 
 public class BonemealEventGrapes
 {
-	@SubscribeEvent
-	public void onUseBonemeal(BonemealEvent event)
+	private void bonemealGrapeVine0(BonemealEvent event)
 	{
-		if (event.block == GrowthCraftGrapes.grapeVine0)
-		{
-			BlockGrapeVine0 vine = (BlockGrapeVine0)event.block;
-			int meta = event.world.getBlockMetadata(event.x, event.y, event.z);
+		BlockGrapeVine0 vine = (BlockGrapeVine0)event.block;
+		int meta = event.world.getBlockMetadata(event.x, event.y, event.z);
 
+		if (!event.world.isRemote)
+		{
+			int i = MathHelper.getRandomIntegerInRange(event.world.rand, 1, 2);
+			if (meta == 0)
+			{
+				if (i == 1)
+				{
+					vine.incrementGrowth(event.world, event.x, event.y, event.z, meta);
+				}
+				else if (i == 2)
+				{
+					event.world.setBlock(event.x, event.y, event.z, GrowthCraftGrapes.grapeVine1, 0, BlockFlags.UPDATE_CLIENT);
+				}
+			}
+			else if (meta == 1)
+			{
+				if (i == 1)
+				{
+					event.world.setBlock(event.x, event.y, event.z, GrowthCraftGrapes.grapeVine1, 0, BlockFlags.UPDATE_CLIENT);
+				}
+				else if (i == 2)
+				{
+					if (event.world.getBlock(event.x, event.y + 1, event.z) == GrowthCraftCore.ropeBlock)
+					{
+						event.world.setBlock(event.x, event.y, event.z, GrowthCraftGrapes.grapeVine1, 1, BlockFlags.UPDATE_CLIENT);
+						event.world.setBlock(event.x, event.y + 1, event.z, GrowthCraftGrapes.grapeLeaves, 0, BlockFlags.UPDATE_CLIENT);
+					}
+					else
+					{
+						event.world.setBlock(event.x, event.y, event.z, GrowthCraftGrapes.grapeVine1, 0, BlockFlags.UPDATE_CLIENT);
+					}
+				}
+			}
+		}
+		event.setResult(Result.ALLOW);
+	}
+
+	private void bonemealGrapeVine1(BonemealEvent event)
+	{
+		BlockGrapeVine1 vine = (BlockGrapeVine1)event.block;
+		int meta = event.world.getBlockMetadata(event.x, event.y, event.z);
+		if (meta == 0 && event.world.getBlock(event.x, event.y + 1, event.z) == GrowthCraftCore.ropeBlock)
+		{
 			if (!event.world.isRemote)
 			{
-				int i = MathHelper.getRandomIntegerInRange(event.world.rand, 1, 2);
-				if (meta == 0)
-				{
-					if (i == 1)
-					{
-						vine.incrementGrowth(event.world, event.x, event.y, event.z, meta);
-					}
-					else if (i == 2)
-					{
-						event.world.setBlock(event.x, event.y, event.z, GrowthCraftGrapes.grapeVine1, 0, 2);
-					}
-				}
-				else if (meta == 1)
-				{
-					if (i == 1)
-					{
-						event.world.setBlock(event.x, event.y, event.z, GrowthCraftGrapes.grapeVine1, 0, 2);
-					}
-					else if (i == 2)
-					{
-						if (event.world.getBlock(event.x, event.y + 1, event.z) == GrowthCraftCore.ropeBlock)
-						{
-							event.world.setBlock(event.x, event.y, event.z, GrowthCraftGrapes.grapeVine1, 1, 2);
-							event.world.setBlock(event.x, event.y + 1, event.z, GrowthCraftGrapes.grapeLeaves, 0, 2);
-						}
-						else
-						{
-							event.world.setBlock(event.x, event.y, event.z, GrowthCraftGrapes.grapeVine1, 0, 2);
-						}
-					}
-				}
+				vine.incrementGrowth(event.world, event.x, event.y, event.z, meta);
+				event.world.setBlock(event.x, event.y + 1, event.z, GrowthCraftGrapes.grapeLeaves, 0, BlockFlags.UPDATE_CLIENT);
 			}
 			event.setResult(Result.ALLOW);
 		}
-		else if (event.block == GrowthCraftGrapes.grapeVine1)
+		if (meta == 0 && event.world.isAirBlock(event.x, event.y + 1, event.z))
 		{
-			BlockGrapeVine1 vine = (BlockGrapeVine1)event.block;
-			int meta = event.world.getBlockMetadata(event.x, event.y, event.z);
-			if (meta == 0 && event.world.getBlock(event.x, event.y + 1, event.z) == GrowthCraftCore.ropeBlock)
+			if (!event.world.isRemote)
 			{
-				if (!event.world.isRemote)
-				{
-					vine.incrementGrowth(event.world, event.x, event.y, event.z, meta);
-					event.world.setBlock(event.x, event.y + 1, event.z, GrowthCraftGrapes.grapeLeaves, 0, 2);
-				}
-				event.setResult(Result.ALLOW);
+				vine.incrementGrowth(event.world, event.x, event.y, event.z, meta);
+				event.world.setBlock(event.x, event.y + 1, event.z, GrowthCraftGrapes.grapeVine1, 0, BlockFlags.UPDATE_CLIENT);
 			}
-			if (meta == 0 && event.world.isAirBlock(event.x, event.y + 1, event.z))
+			event.setResult(Result.ALLOW);
+		}
+		else if (meta == 0 && event.world.getBlock(event.x, event.y + 1, event.z) ==  GrowthCraftGrapes.grapeLeaves)
+		{
+			if (!event.world.isRemote)
 			{
-				if (!event.world.isRemote)
-				{
-					vine.incrementGrowth(event.world, event.x, event.y, event.z, meta);
-					event.world.setBlock(event.x, event.y + 1, event.z, GrowthCraftGrapes.grapeVine1, 0, 2);
-				}
-				event.setResult(Result.ALLOW);
+				vine.incrementGrowth(event.world, event.x, event.y, event.z, meta);
 			}
-			else if (meta == 0 && event.world.getBlock(event.x, event.y + 1, event.z) ==  GrowthCraftGrapes.grapeLeaves)
+			event.setResult(Result.ALLOW);
+		}
+		else
+		{
+			event.setResult(Result.DENY);
+		}
+	}
+
+	private void bonemealGrapeLeaves(BonemealEvent event)
+	{
+		boolean flag = !checkValidity(event.world, event.x, event.y, event.z - 1);
+		boolean flag1 = !checkValidity(event.world, event.x, event.y, event.z + 1);
+		boolean flag2 = !checkValidity(event.world, event.x - 1, event.y, event.z);
+		boolean flag3 = !checkValidity(event.world, event.x + 1, event.y, event.z);
+
+		if (flag1 && flag2 && flag3 && flag)
+		{
+			if (event.world.isAirBlock(event.x, event.y - 1, event.z))
 			{
 				if (!event.world.isRemote)
 				{
-					vine.incrementGrowth(event.world, event.x, event.y, event.z, meta);
+					event.world.setBlock(event.x, event.y - 1, event.z, GrowthCraftGrapes.grapeBlock, 0, BlockFlags.UPDATE_CLIENT);
 				}
 				event.setResult(Result.ALLOW);
 			}
@@ -92,61 +114,54 @@ public class BonemealEventGrapes
 				event.setResult(Result.DENY);
 			}
 		}
+		else
+		{
+			if (!event.world.isRemote)
+			{
+				int r = event.world.rand.nextInt(4);
+
+				if (r == 0 && checkValidity(event.world, event.x, event.y, event.z - 1))
+				{
+					event.world.setBlock(event.x, event.y, event.z - 1, GrowthCraftGrapes.grapeLeaves, 0, BlockFlags.UPDATE_CLIENT);
+					return;
+				}
+
+				if (r == 1 && checkValidity(event.world, event.x, event.y, event.z + 1))
+				{
+					event.world.setBlock(event.x, event.y, event.z + 1, GrowthCraftGrapes.grapeLeaves, 0, BlockFlags.UPDATE_CLIENT);
+					return;
+				}
+
+				if (r == 2 && checkValidity(event.world, event.x - 1, event.y, event.z))
+				{
+					event.world.setBlock(event.x - 1, event.y, event.z, GrowthCraftGrapes.grapeLeaves, 0, BlockFlags.UPDATE_CLIENT);
+					return;
+				}
+
+				if (r == 3 && checkValidity(event.world, event.x + 1, event.y, event.z))
+				{
+					event.world.setBlock(event.x + 1, event.y, event.z, GrowthCraftGrapes.grapeLeaves, 0, BlockFlags.UPDATE_CLIENT);
+					return;
+				}
+			}
+			event.setResult(Result.ALLOW);
+		}
+	}
+
+	@SubscribeEvent
+	public void onUseBonemeal(BonemealEvent event)
+	{
+		if (event.block == GrowthCraftGrapes.grapeVine0)
+		{
+			bonemealGrapeVine0(event);
+		}
+		else if (event.block == GrowthCraftGrapes.grapeVine1)
+		{
+			bonemealGrapeVine1(event);
+		}
 		else if (event.block == GrowthCraftGrapes.grapeLeaves)
 		{
-			boolean flag = !checkValidity(event.world, event.x, event.y, event.z - 1);
-			boolean flag1 = !checkValidity(event.world, event.x, event.y, event.z + 1);
-			boolean flag2 = !checkValidity(event.world, event.x - 1, event.y, event.z);
-			boolean flag3 = !checkValidity(event.world, event.x + 1, event.y, event.z);
-
-			if (flag1 && flag2 && flag3 && flag)
-			{
-				if (event.world.isAirBlock(event.x, event.y - 1, event.z))
-				{
-					if (!event.world.isRemote)
-					{
-						event.world.setBlock(event.x, event.y - 1, event.z, GrowthCraftGrapes.grapeBlock);
-					}
-					event.setResult(Result.ALLOW);
-				}
-				else
-				{
-					event.setResult(Result.DENY);
-				}
-			}
-			else
-			{
-				if (!event.world.isRemote)
-				{
-					int r = event.world.rand.nextInt(4);
-
-					if (r == 0 && checkValidity(event.world, event.x, event.y, event.z - 1))
-					{
-						event.world.setBlock(event.x, event.y, event.z - 1, GrowthCraftGrapes.grapeLeaves);
-						return;
-					}
-
-					if (r == 1 && checkValidity(event.world, event.x, event.y, event.z + 1))
-					{
-						event.world.setBlock(event.x, event.y, event.z + 1, GrowthCraftGrapes.grapeLeaves);
-						return;
-					}
-
-					if (r == 2 && checkValidity(event.world, event.x - 1, event.y, event.z))
-					{
-						event.world.setBlock(event.x - 1, event.y, event.z, GrowthCraftGrapes.grapeLeaves);
-						return;
-					}
-
-					if (r == 3 && checkValidity(event.world, event.x + 1, event.y, event.z))
-					{
-						event.world.setBlock(event.x + 1, event.y, event.z, GrowthCraftGrapes.grapeLeaves);
-						return;
-					}
-				}
-
-				event.setResult(Result.ALLOW);
-			}
+			bonemealGrapeLeaves(event);
 		}
 	}
 


### PR DESCRIPTION
For #97
In addition to trying to figure out how the hell grape growth works...
Its really odd, you bonemeal the `leaves` and then bonemeal the `rope` to spread the leaves...
## What does this do?

This change introduces the ability to right click apples and grapes to drop them as items vs breaking them like normal.
## Builds
### Latest

[Build 1](https://dl.dropboxusercontent.com/u/72618186/minecraft/mods/growthcraft/2.2.2/growthcraft-1.7.10-2.2.2-complete_consistent-right-clicks-build1.jar)
### Old

[Build 0](https://dl.dropboxusercontent.com/u/72618186/minecraft/mods/growthcraft/2.2.2/growthcraft-1.7.10-2.2.2-complete_consistent-right-clicks-build0.jar)

**p.s** Happy 101st issue
