### PR TITLE
api/core/effects: Serializable effects

### DIFF
--- a/src/java/growthcraft/api/cellar/booze/BoozeEffect.java
+++ b/src/java/growthcraft/api/cellar/booze/BoozeEffect.java
@@ -27,17 +27,21 @@ import java.util.List;
 import java.util.Random;
 import javax.annotation.Nonnull;
 
-import growthcraft.api.core.effect.IEffect;
-import growthcraft.api.core.effect.EffectList;
-import growthcraft.api.core.effect.EffectAddPotionEffect;
 import growthcraft.api.cellar.booze.effect.EffectTipsy;
+import growthcraft.api.core.CoreRegistry;
+import growthcraft.api.core.effect.AbstractEffect;
+import growthcraft.api.core.effect.EffectAddPotionEffect;
+import growthcraft.api.core.effect.EffectList;
+import growthcraft.api.core.effect.IEffect;
 
-import net.minecraft.world.World;
 import net.minecraft.entity.Entity;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.Potion;
+import net.minecraft.world.World;
 import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
 
-public class BoozeEffect implements IEffect
+public class BoozeEffect extends AbstractEffect
 {
 	static class BoozeEffectList extends EffectList
 	{
@@ -64,6 +68,8 @@ public class BoozeEffect implements IEffect
 	{
 		this.booze = flu;
 	}
+
+	public BoozeEffect() {}
 
 	public BoozeEffect clearEffects()
 	{
@@ -127,15 +133,47 @@ public class BoozeEffect implements IEffect
 		return canCauseTipsy() || hasEffects();
 	}
 
+	@Override
 	public void apply(World world, Entity entity, Random random, Object data)
 	{
 		if (tipsyEffect != null) tipsyEffect.apply(world, entity, random, data);
 		effects.apply(world, entity, random, data);
 	}
 
+	@Override
 	public void getDescription(List<String> list)
 	{
 		if (tipsyEffect != null) tipsyEffect.getDescription(list);
 		effects.getDescription(list);
+	}
+
+	@Override
+	protected void readFromNBT(NBTTagCompound data)
+	{
+		this.booze = null;
+		this.tipsyEffect = null;
+		if (data.hasKey("tipsy_effect"))
+		{
+			this.tipsyEffect = (EffectTipsy)CoreRegistry.instance().getEffectsRegistry().loadEffectFromNBT(data, "tipsy_effect");
+		}
+		this.effects = (BoozeEffectList)CoreRegistry.instance().getEffectsRegistry().loadEffectFromNBT(data, "effects");
+		if (data.hasKey("fluid.name"))
+		{
+			this.booze = FluidRegistry.getFluid(data.getString("fluid.name"));
+		}
+	}
+
+	@Override
+	protected void writeToNBT(NBTTagCompound data)
+	{
+		if (tipsyEffect != null)
+		{
+			tipsyEffect.writeToNBT(data, "tipsy_effect");
+		}
+		effects.writeToNBT(data, "effects");
+		if (booze != null)
+		{
+			data.setString("fluid.name", booze.getName());
+		}
 	}
 }

--- a/src/java/growthcraft/api/cellar/booze/BoozePotionEffectFactory.java
+++ b/src/java/growthcraft/api/cellar/booze/BoozePotionEffectFactory.java
@@ -30,13 +30,16 @@ import java.util.Collection;
 import javax.annotation.Nonnull;
 
 import growthcraft.api.cellar.CellarRegistry;
+import growthcraft.api.core.CoreRegistry;
 import growthcraft.api.core.description.Describer;
 import growthcraft.api.core.effect.IPotionEffectFactory;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.world.World;
 import net.minecraftforge.fluids.Fluid;
+import net.minecraftforge.fluids.FluidRegistry;
 
 public class BoozePotionEffectFactory implements IPotionEffectFactory
 {
@@ -94,5 +97,54 @@ public class BoozePotionEffectFactory implements IPotionEffectFactory
 	{
 		final PotionEffect pe = createPotionEffect(null, null, null, null);
 		Describer.getPotionEffectDescription(list, pe);
+	}
+
+	private void readFromNBT(NBTTagCompound data)
+	{
+		this.booze = null;
+		this.id = data.getInteger("id");
+		this.time = data.getInteger("time");
+		this.level = data.getInteger("level");
+		if (data.hasKey("fluid.name"))
+		{
+			this.booze = FluidRegistry.getFluid(data.getString("fluid.name"));
+		}
+	}
+
+	@Override
+	public void readFromNBT(NBTTagCompound data, String name)
+	{
+		if (data.hasKey(name))
+		{
+			final NBTTagCompound subData = data.getCompoundTag(name);
+			readFromNBT(subData);
+		}
+		else
+		{
+			// LOG error
+		}
+	}
+
+	private void writeToNBT(NBTTagCompound data)
+	{
+		data.setInteger("id", getID());
+		data.setInteger("time", getTime());
+		data.setInteger("level", getLevel());
+		if (booze != null)
+		{
+			data.setString("fluid.name", booze.getName());
+		}
+	}
+
+	@Override
+	public void writeToNBT(NBTTagCompound data, String name)
+	{
+		final NBTTagCompound target = new NBTTagCompound();
+		final String factoryName = CoreRegistry.instance().getPotionEffectFactoryRegistry().getName(this.getClass());
+
+		target.setString("__name__", factoryName);
+		writeToNBT(target);
+
+		data.setTag(name, target);
 	}
 }

--- a/src/java/growthcraft/api/cellar/booze/effect/EffectTipsy.java
+++ b/src/java/growthcraft/api/cellar/booze/effect/EffectTipsy.java
@@ -26,20 +26,21 @@ package growthcraft.api.cellar.booze.effect;
 import java.util.Random;
 import java.util.List;
 
-import growthcraft.api.core.effect.IEffect;
+import growthcraft.api.core.effect.AbstractEffect;
 import growthcraft.api.core.i18n.GrcI18n;
 import growthcraft.api.core.stats.IAchievement;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.Potion;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.util.EnumChatFormatting;
 import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
 
-public class EffectTipsy implements IEffect
+public class EffectTipsy extends AbstractEffect
 {
 	public static Potion potionTipsy;
 	public static IAchievement achievement;
@@ -78,6 +79,7 @@ public class EffectTipsy implements IEffect
 		return tipsyTime;
 	}
 
+	@Override
 	public void apply(World world, Entity entity, Random random, Object data)
 	{
 		if (entity instanceof EntityLivingBase)
@@ -117,6 +119,7 @@ public class EffectTipsy implements IEffect
 		}
 	}
 
+	@Override
 	public void getDescription(List<String> list)
 	{
 		final PotionEffect nausea = new PotionEffect(Potion.confusion.id, getTipsyTime(), 0);
@@ -128,5 +131,21 @@ public class EffectTipsy implements IEffect
 			n = "(" + Potion.getDurationString(nausea) + ")";
 		}
 		list.add(EnumChatFormatting.GRAY + p + EnumChatFormatting.GRAY + " " + n);
+	}
+
+	@Override
+	protected void readFromNBT(NBTTagCompound data)
+	{
+		this.hasTipsyEffect = data.getBoolean("has_tipsy_effect");
+		this.tipsyChance = data.getFloat("tipsy_chance");
+		this.tipsyTime = data.getInteger("tipsy_time");
+	}
+
+	@Override
+	protected void writeToNBT(NBTTagCompound data)
+	{
+		data.setBoolean("has_tipsy_effect", hasTipsyEffect);
+		data.setFloat("tipsy_chance", tipsyChance);
+		data.setInteger("tipsy_time", tipsyTime);
 	}
 }

--- a/src/java/growthcraft/api/core/AbstractClassRegistry.java
+++ b/src/java/growthcraft/api/core/AbstractClassRegistry.java
@@ -1,0 +1,114 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 IceDragon200
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package growthcraft.api.core;
+
+import javax.annotation.Nonnull;
+
+import growthcraft.api.core.nbt.INBTSerializable;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+
+import net.minecraft.nbt.NBTTagCompound;
+
+/**
+ * Don't even try to understand this, save yourself the trouble.
+ */
+public abstract class AbstractClassRegistry<T extends INBTSerializable> implements IClassRegistry<T>
+{
+	/**
+	 * Error raised when an attempt is made to register an effect under an existing name
+	 */
+	public static class ClassRegisteredException extends RuntimeException
+	{
+		public static final long serialVersionUID = 1L;
+
+		public ClassRegisteredException(@Nonnull String msg)
+		{
+			super(msg);
+		}
+
+		public ClassRegisteredException() {}
+	}
+
+	private BiMap<String, Class<?>> effects = HashBiMap.create();
+
+	public Class<T> getClass(@Nonnull String name)
+	{
+		final Class<?> klass = effects.get(name);
+		return (Class<T>)klass;
+	}
+
+	public String getName(@Nonnull Class<?> klass)
+	{
+		return effects.inverse().get(klass);
+	}
+
+	public void register(@Nonnull String name, @Nonnull Class<T> klass)
+	{
+		if (effects.containsKey(name))
+		{
+			final Class<T> effect = getClass(name);
+			throw new ClassRegisteredException("Cannot register " + klass + ", Effect " + effect + " is already registered to " + name);
+		}
+		else
+		{
+			effects.put(name, klass);
+		}
+	}
+
+	/**
+	 * Mother of hacks batman!
+	 *
+	 * @param data - nbt data to load from
+	 * @param name - key to load data from
+	 * @return T an instance of the class to reload
+	 */
+	public T loadObjectFromNBT(@Nonnull NBTTagCompound data, @Nonnull String name)
+	{
+		final NBTTagCompound effectData = data.getCompoundTag(name);
+		final String factoryName = data.getString("__name__");
+		final Class<T> klass = getClass(factoryName);
+
+		T instance = null;
+
+		// This should be a utility method in the future or something, its used so much now...
+		try
+		{
+			instance = klass.newInstance();
+		}
+		catch (InstantiationException e)
+		{
+			throw new IllegalStateException("Failed to create a new instance of an illegal class " + klass, e);
+		}
+		catch (IllegalAccessException e)
+		{
+			throw new IllegalStateException("Failed to create a new instance of " + klass + ", because lack of permissions", e);
+		}
+
+		instance.readFromNBT(data, name);
+
+		return instance;
+	}
+}

--- a/src/java/growthcraft/api/core/CoreRegistry.java
+++ b/src/java/growthcraft/api/core/CoreRegistry.java
@@ -34,6 +34,7 @@ public class CoreRegistry implements ILoggable
 	protected ILogger logger = NullLogger.INSTANCE;
 	private final List<VineEntry> vineList = new ArrayList<VineEntry>();
 	private final IEffectRegistry effectRegistry = new EffectRegistry();
+	private final IPotionEffectFactoryRegistry potionEffectFactoryRegistry = new PotionEffectFactoryRegistry();
 
 	/**
 	 * @return vine drop list
@@ -45,14 +46,24 @@ public class CoreRegistry implements ILoggable
 		return instance;
 	}
 
-	public IEffectRegistry getEffectRegistry()
+	public IEffectRegistry getEffectsRegistry()
 	{
 		return effectRegistry;
+	}
+
+	public IPotionEffectFactoryRegistry getPotionEffectFactoryRegistry()
+	{
+		return potionEffectFactoryRegistry;
 	}
 
 	public void setLogger(ILogger l)
 	{
 		this.logger = l;
+	}
+
+	public ILogger getLogger()
+	{
+		return logger;
 	}
 
 	///////////////////////////////////////////////////////////////////////

--- a/src/java/growthcraft/api/core/CoreRegistry.java
+++ b/src/java/growthcraft/api/core/CoreRegistry.java
@@ -33,6 +33,7 @@ public class CoreRegistry implements ILoggable
 
 	protected ILogger logger = NullLogger.INSTANCE;
 	private final List<VineEntry> vineList = new ArrayList<VineEntry>();
+	private final IEffectRegistry effectRegistry = new EffectRegistry();
 
 	/**
 	 * @return vine drop list
@@ -42,6 +43,11 @@ public class CoreRegistry implements ILoggable
 	public static final CoreRegistry instance()
 	{
 		return instance;
+	}
+
+	public IEffectRegistry getEffectRegistry()
+	{
+		return effectRegistry;
 	}
 
 	public void setLogger(ILogger l)

--- a/src/java/growthcraft/api/core/EffectRegistry.java
+++ b/src/java/growthcraft/api/core/EffectRegistry.java
@@ -1,0 +1,75 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 IceDragon200
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package growthcraft.api.core;
+
+import javax.annotation.Nonnull;
+
+import growthcraft.api.core.effect.IEffect;
+
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+
+public class EffectRegistry implements IEffectRegistry
+{
+	/**
+	 * Error raised when an attempt is made to register an effect under an existing name
+	 */
+	public static class EffectRegisteredException extends RuntimeException
+	{
+		public static final long serialVersionUID = 1L;
+
+		public EffectRegisteredException(@Nonnull String msg)
+		{
+			super(msg);
+		}
+
+		public EffectRegisteredException() {}
+	}
+
+	private BiMap<String, Class<IEffect>> effects = HashBiMap.create();
+
+	public IEffectRegistry register(@Nonnull String name, @Nonnull Class<IEffect> effectClass)
+	{
+		if (effects.containsKey(name))
+		{
+			final Class<IEffect> effect = getClass(name);
+			throw new EffectRegisteredException("Cannot register " + effectClass + ", Effect " + effect + " is already registered to " + name);
+		}
+		else
+		{
+			effects.put(name, effectClass);
+		}
+		return this;
+	}
+
+	public Class<IEffect> getClass(@Nonnull String name)
+	{
+		return effects.get(name);
+	}
+
+	public String getName(@Nonnull Class<IEffect> effectClass)
+	{
+		return effects.inverse().get(effectClass);
+	}
+}

--- a/src/java/growthcraft/api/core/IClassRegistry.java
+++ b/src/java/growthcraft/api/core/IClassRegistry.java
@@ -25,14 +25,24 @@ package growthcraft.api.core;
 
 import javax.annotation.Nonnull;
 
-import growthcraft.api.core.effect.IEffect;
-
-import net.minecraft.nbt.NBTTagCompound;
-
-public class EffectRegistry extends AbstractClassRegistry<IEffect> implements IEffectRegistry
+public interface IClassRegistry<T>
 {
-	public IEffect loadEffectFromNBT(@Nonnull NBTTagCompound data, @Nonnull String name)
-	{
-		return loadObjectFromNBT(data, name);
-	}
+	/**
+	 * @param name - Name to register it under
+	 * @param klass - A class
+	 * @return factory registry
+	 */
+	void register(@Nonnull String name, @Nonnull Class<T> klass);
+
+	/**
+	 * @param name - name of factory class to fetch
+	 * @return factory class
+	 */
+	Class<T> getClass(@Nonnull String name);
+
+	/**
+	 * @param klass - factory class to fetch name for
+	 * @return name
+	 */
+	String getName(@Nonnull Class<?> klass);
 }

--- a/src/java/growthcraft/api/core/IEffectRegistry.java
+++ b/src/java/growthcraft/api/core/IEffectRegistry.java
@@ -1,0 +1,50 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2016 IceDragon200
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package growthcraft.api.core;
+
+import javax.annotation.Nonnull;
+
+import growthcraft.api.core.effect.IEffect;
+
+public interface IEffectRegistry
+{
+	/**
+	 * @param name - Name to register it under
+	 * @param effectClass - An IEffect class
+	 * @return effect registry
+	 */
+	IEffectRegistry register(@Nonnull String name, @Nonnull Class<IEffect> effectClass);
+
+	/**
+	 * @param name - name of effect class to fetch
+	 * @return effect class
+	 */
+	Class<IEffect> getClass(@Nonnull String name);
+
+	/**
+	 * @param effectClass - effect class to fetch name for
+	 * @return name
+	 */
+	String getName(@Nonnull Class<IEffect> effectClass);
+}

--- a/src/java/growthcraft/api/core/IEffectRegistry.java
+++ b/src/java/growthcraft/api/core/IEffectRegistry.java
@@ -27,24 +27,14 @@ import javax.annotation.Nonnull;
 
 import growthcraft.api.core.effect.IEffect;
 
-public interface IEffectRegistry
+import net.minecraft.nbt.NBTTagCompound;
+
+public interface IEffectRegistry extends IClassRegistry<IEffect>
 {
 	/**
-	 * @param name - Name to register it under
-	 * @param effectClass - An IEffect class
-	 * @return effect registry
-	 */
-	IEffectRegistry register(@Nonnull String name, @Nonnull Class<IEffect> effectClass);
-
-	/**
-	 * @param name - name of effect class to fetch
-	 * @return effect class
-	 */
-	Class<IEffect> getClass(@Nonnull String name);
-
-	/**
-	 * @param effectClass - effect class to fetch name for
+	 * @param data  - nbt data to load
+	 * @param name  - tag to load
 	 * @return name
 	 */
-	String getName(@Nonnull Class<IEffect> effectClass);
+	IEffect loadEffectFromNBT(@Nonnull NBTTagCompound data, @Nonnull String name);
 }

--- a/src/java/growthcraft/api/core/IPotionEffectFactoryRegistry.java
+++ b/src/java/growthcraft/api/core/IPotionEffectFactoryRegistry.java
@@ -25,14 +25,16 @@ package growthcraft.api.core;
 
 import javax.annotation.Nonnull;
 
-import growthcraft.api.core.effect.IEffect;
+import growthcraft.api.core.effect.IPotionEffectFactory;
 
 import net.minecraft.nbt.NBTTagCompound;
 
-public class EffectRegistry extends AbstractClassRegistry<IEffect> implements IEffectRegistry
+public interface IPotionEffectFactoryRegistry extends IClassRegistry<IPotionEffectFactory>
 {
-	public IEffect loadEffectFromNBT(@Nonnull NBTTagCompound data, @Nonnull String name)
-	{
-		return loadObjectFromNBT(data, name);
-	}
+	/**
+	 * @param data  - nbt data to load
+	 * @param name  - tag to load
+	 * @return name
+	 */
+	IPotionEffectFactory loadPotionEffectFactoryFromNBT(@Nonnull NBTTagCompound data, @Nonnull String name);
 }

--- a/src/java/growthcraft/api/core/PotionEffectFactoryRegistry.java
+++ b/src/java/growthcraft/api/core/PotionEffectFactoryRegistry.java
@@ -25,13 +25,13 @@ package growthcraft.api.core;
 
 import javax.annotation.Nonnull;
 
-import growthcraft.api.core.effect.IEffect;
+import growthcraft.api.core.effect.IPotionEffectFactory;
 
 import net.minecraft.nbt.NBTTagCompound;
 
-public class EffectRegistry extends AbstractClassRegistry<IEffect> implements IEffectRegistry
+public class PotionEffectFactoryRegistry extends AbstractClassRegistry<IPotionEffectFactory> implements IPotionEffectFactoryRegistry
 {
-	public IEffect loadEffectFromNBT(@Nonnull NBTTagCompound data, @Nonnull String name)
+	public IPotionEffectFactory loadPotionEffectFactoryFromNBT(@Nonnull NBTTagCompound data, @Nonnull String name)
 	{
 		return loadObjectFromNBT(data, name);
 	}

--- a/src/java/growthcraft/api/core/effect/AbstractEffect.java
+++ b/src/java/growthcraft/api/core/effect/AbstractEffect.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015, 2016 IceDragon200
+ * Copyright (c) 2016 IceDragon200
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,26 +23,40 @@
  */
 package growthcraft.api.core.effect;
 
-import java.util.List;
-import java.util.Random;
+import growthcraft.api.core.CoreRegistry;
 
-import growthcraft.api.core.i18n.GrcI18n;
-
-import net.minecraft.entity.Entity;
-import net.minecraft.world.World;
+import net.minecraft.nbt.NBTTagCompound;
 
 /**
  * Because sometimes you want an Effect that does ABSOLUTELY NOTHING.
  */
-public class EffectNull extends AbstractEffect
+public abstract class AbstractEffect implements IEffect
 {
-	@Override
-	public void apply(World world, Entity entity, Random random, Object data) {}
+	protected abstract void readFromNBT(NBTTagCompound data);
+	protected abstract void writeToNBT(NBTTagCompound data);
 
 	@Override
-	public void getDescription(List<String> list)
+	public void readFromNBT(NBTTagCompound data, String name)
 	{
-		// Set the description as "Does Nothing."
-		list.add(GrcI18n.translate("grc.effect.null.desc"));
+		if (data.hasKey(name))
+		{
+			final NBTTagCompound effectData = data.getCompoundTag(name);
+			readFromNBT(effectData);
+		}
+		else
+		{
+			// LOG error
+		}
+	}
+
+	@Override
+	public void writeToNBT(NBTTagCompound data, String name)
+	{
+		final NBTTagCompound target = new NBTTagCompound();
+		final String effectName = CoreRegistry.instance().getEffectRegistry().getName(this.getClass());
+		// This is a VERY important field, this is how the effects will reload their correct class.
+		target.setString("__name__", effectName);
+		writeToNBT(target);
+		data.setTag(name, target);
 	}
 }

--- a/src/java/growthcraft/api/core/effect/AbstractEffect.java
+++ b/src/java/growthcraft/api/core/effect/AbstractEffect.java
@@ -33,7 +33,6 @@ import net.minecraft.nbt.NBTTagCompound;
 public abstract class AbstractEffect implements IEffect
 {
 	protected abstract void readFromNBT(NBTTagCompound data);
-	protected abstract void writeToNBT(NBTTagCompound data);
 
 	@Override
 	public void readFromNBT(NBTTagCompound data, String name)
@@ -49,14 +48,17 @@ public abstract class AbstractEffect implements IEffect
 		}
 	}
 
+	protected abstract void writeToNBT(NBTTagCompound data);
+
 	@Override
 	public void writeToNBT(NBTTagCompound data, String name)
 	{
 		final NBTTagCompound target = new NBTTagCompound();
-		final String effectName = CoreRegistry.instance().getEffectRegistry().getName(this.getClass());
+		final String effectName = CoreRegistry.instance().getEffectsRegistry().getName(this.getClass());
 		// This is a VERY important field, this is how the effects will reload their correct class.
 		target.setString("__name__", effectName);
 		writeToNBT(target);
+
 		data.setTag(name, target);
 	}
 }

--- a/src/java/growthcraft/api/core/effect/AbstractEffectList.java
+++ b/src/java/growthcraft/api/core/effect/AbstractEffectList.java
@@ -27,6 +27,10 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nonnull;
 
+import growthcraft.api.core.nbt.NBTHelper;
+
+import net.minecraft.nbt.NBTTagCompound;
+
 /**
  * Base class for defining Effect lists
  */
@@ -113,5 +117,18 @@ public abstract class AbstractEffectList extends AbstractEffect
 	public int size()
 	{
 		return effects.size();
+	}
+
+	@Override
+	protected void readFromNBT(NBTTagCompound data)
+	{
+		effects.clear();
+		NBTHelper.loadEffectsList(effects, data);
+	}
+
+	@Override
+	protected void writeToNBT(NBTTagCompound data)
+	{
+		NBTHelper.writeEffectsList(data, effects);
 	}
 }

--- a/src/java/growthcraft/api/core/effect/AbstractEffectList.java
+++ b/src/java/growthcraft/api/core/effect/AbstractEffectList.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 IceDragon200
+ * Copyright (c) 2015, 2016 IceDragon200
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -30,7 +30,7 @@ import javax.annotation.Nonnull;
 /**
  * Base class for defining Effect lists
  */
-public abstract class AbstractEffectList implements IEffect
+public abstract class AbstractEffectList extends AbstractEffect
 {
 	protected List<IEffect> effects = new ArrayList<IEffect>();
 

--- a/src/java/growthcraft/api/core/effect/EffectAddPotionEffect.java
+++ b/src/java/growthcraft/api/core/effect/EffectAddPotionEffect.java
@@ -27,8 +27,11 @@ import java.util.List;
 import java.util.Random;
 import javax.annotation.Nonnull;
 
+import growthcraft.api.core.CoreRegistry;
+
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.world.World;
 
@@ -71,6 +74,8 @@ public class EffectAddPotionEffect extends AbstractEffect
 	@Override
 	public void apply(World world, Entity entity, Random random, Object data)
 	{
+		if (potionFactory == null) return;
+
 		if (entity instanceof EntityLivingBase)
 		{
 			final PotionEffect effect = potionFactory.createPotionEffect(world, entity, random, data);
@@ -82,6 +87,25 @@ public class EffectAddPotionEffect extends AbstractEffect
 	@Override
 	public void getDescription(List<String> list)
 	{
+		if (potionFactory == null) return;
 		potionFactory.getDescription(list);
+	}
+
+	@Override
+	protected void readFromNBT(NBTTagCompound data)
+	{
+		if (data.hasKey("potion_factory"))
+		{
+			this.potionFactory = CoreRegistry.instance().getPotionEffectFactoryRegistry().loadPotionEffectFactoryFromNBT(data, "potion_factory");
+		}
+	}
+
+	@Override
+	protected void writeToNBT(NBTTagCompound data)
+	{
+		if (potionFactory != null)
+		{
+			potionFactory.writeToNBT(data, "potion_factory");
+		}
 	}
 }

--- a/src/java/growthcraft/api/core/effect/EffectAddPotionEffect.java
+++ b/src/java/growthcraft/api/core/effect/EffectAddPotionEffect.java
@@ -35,7 +35,7 @@ import net.minecraft.world.World;
 /**
  * As its name implies, this Effect, will ADD a Potion Effect to the target.
  */
-public class EffectAddPotionEffect implements IEffect
+public class EffectAddPotionEffect extends AbstractEffect
 {
 	private IPotionEffectFactory potionFactory;
 
@@ -52,6 +52,9 @@ public class EffectAddPotionEffect implements IEffect
 		return this;
 	}
 
+	/**
+	 * @return potion factory
+	 */
 	public IPotionEffectFactory getPotionFactory()
 	{
 		return potionFactory;

--- a/src/java/growthcraft/api/core/effect/EffectChance.java
+++ b/src/java/growthcraft/api/core/effect/EffectChance.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 IceDragon200
+ * Copyright (c) 2015, 2016 IceDragon200
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,18 +29,23 @@ import java.util.Random;
 
 import growthcraft.api.core.i18n.GrcI18n;
 import growthcraft.api.core.description.Describer;
+import growthcraft.api.core.CoreRegistry;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 
 /**
  * Has a random chance of applying its sub effect to the target
  */
-public class EffectChance implements IEffect
+public class EffectChance extends AbstractEffect
 {
 	private float chance;
 	private IEffect effect;
 
+	/**
+	 * @param effekt - the effect to apply when the conditions are met
+	 */
 	public EffectChance(IEffect effekt)
 	{
 		this.effect = effekt;
@@ -94,6 +99,22 @@ public class EffectChance implements IEffect
 				final String str = GrcI18n.translate("grc.effect.chance.format", (int)(chance * 100));
 				Describer.compactDescription(str, list, tempList);
 			}
+		}
+	}
+
+	@Override
+	protected void readFromNBT(NBTTagCompound data)
+	{
+
+	}
+
+	@Override
+	protected void writeToNBT(NBTTagCompound data)
+	{
+		data.setFloat("chance", chance);
+		if (effect)
+		{
+			effect.writeToNBT(data, "effect");
 		}
 	}
 }

--- a/src/java/growthcraft/api/core/effect/EffectChance.java
+++ b/src/java/growthcraft/api/core/effect/EffectChance.java
@@ -27,9 +27,9 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 
-import growthcraft.api.core.i18n.GrcI18n;
-import growthcraft.api.core.description.Describer;
 import growthcraft.api.core.CoreRegistry;
+import growthcraft.api.core.description.Describer;
+import growthcraft.api.core.i18n.GrcI18n;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.nbt.NBTTagCompound;
@@ -105,14 +105,18 @@ public class EffectChance extends AbstractEffect
 	@Override
 	protected void readFromNBT(NBTTagCompound data)
 	{
-
+		this.chance = data.getFloat("chance");
+		if (data.hasKey("effect"))
+		{
+			this.effect = CoreRegistry.instance().getEffectsRegistry().loadEffectFromNBT(data, "effect");
+		}
 	}
 
 	@Override
 	protected void writeToNBT(NBTTagCompound data)
 	{
 		data.setFloat("chance", chance);
-		if (effect)
+		if (effect != null)
 		{
 			effect.writeToNBT(data, "effect");
 		}

--- a/src/java/growthcraft/api/core/effect/EffectList.java
+++ b/src/java/growthcraft/api/core/effect/EffectList.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 IceDragon200
+ * Copyright (c) 2015, 2016 IceDragon200
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/java/growthcraft/api/core/effect/EffectNull.java
+++ b/src/java/growthcraft/api/core/effect/EffectNull.java
@@ -29,6 +29,7 @@ import java.util.Random;
 import growthcraft.api.core.i18n.GrcI18n;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.world.World;
 
 /**
@@ -44,5 +45,15 @@ public class EffectNull extends AbstractEffect
 	{
 		// Set the description as "Does Nothing."
 		list.add(GrcI18n.translate("grc.effect.null.desc"));
+	}
+
+	@Override
+	protected void readFromNBT(NBTTagCompound data)
+	{
+	}
+
+	@Override
+	protected void writeToNBT(NBTTagCompound data)
+	{
 	}
 }

--- a/src/java/growthcraft/api/core/effect/EffectRandomList.java
+++ b/src/java/growthcraft/api/core/effect/EffectRandomList.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 IceDragon200
+ * Copyright (c) 2015, 2016 IceDragon200
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal

--- a/src/java/growthcraft/api/core/effect/EffectRemovePotionEffect.java
+++ b/src/java/growthcraft/api/core/effect/EffectRemovePotionEffect.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 IceDragon200
+ * Copyright (c) 2015, 2016 IceDragon200
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -36,7 +36,7 @@ import net.minecraft.potion.PotionEffect;
 /**
  * As its name implies, this Effect will REMOVE a Potion Effect from the target.
  */
-public class EffectRemovePotionEffect implements IEffect
+public class EffectRemovePotionEffect extends AbstractEffect
 {
 	private int potionId;
 

--- a/src/java/growthcraft/api/core/effect/EffectRemovePotionEffect.java
+++ b/src/java/growthcraft/api/core/effect/EffectRemovePotionEffect.java
@@ -28,10 +28,11 @@ import java.util.Random;
 
 import growthcraft.api.core.i18n.GrcI18n;
 
-import net.minecraft.world.World;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityLivingBase;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.PotionEffect;
+import net.minecraft.world.World;
 
 /**
  * As its name implies, this Effect will REMOVE a Potion Effect from the target.
@@ -39,6 +40,13 @@ import net.minecraft.potion.PotionEffect;
 public class EffectRemovePotionEffect extends AbstractEffect
 {
 	private int potionId;
+
+	public EffectRemovePotionEffect(int potnId)
+	{
+		this.potionId = potnId;
+	}
+
+	public EffectRemovePotionEffect() {}
 
 	public EffectRemovePotionEffect setPotionID(int id)
 	{
@@ -76,5 +84,17 @@ public class EffectRemovePotionEffect extends AbstractEffect
 		final PotionEffect pe = new PotionEffect(getPotionID(), 1000, 0);
 		final String potionName = GrcI18n.translate(pe.getEffectName()).trim();
 		list.add(GrcI18n.translate("grc.effect.remove_potion_effect.format", potionName));
+	}
+
+	@Override
+	protected void readFromNBT(NBTTagCompound data)
+	{
+		this.potionId = data.getInteger("potion_id");
+	}
+
+	@Override
+	protected void writeToNBT(NBTTagCompound data)
+	{
+		data.setInteger("potion_id", potionId);
 	}
 }

--- a/src/java/growthcraft/api/core/effect/EffectWeightedRandomList.java
+++ b/src/java/growthcraft/api/core/effect/EffectWeightedRandomList.java
@@ -28,12 +28,15 @@ import java.util.List;
 import java.util.Random;
 import javax.annotation.Nonnull;
 
-import growthcraft.api.core.i18n.GrcI18n;
+import growthcraft.api.core.CoreRegistry;
 import growthcraft.api.core.description.Describer;
+import growthcraft.api.core.i18n.GrcI18n;
+import growthcraft.api.core.nbt.NBTHelper;
 
 import net.minecraft.entity.Entity;
-import net.minecraft.world.World;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.WeightedRandom;
+import net.minecraft.world.World;
 
 /**
  * A variation of the EffectRandomList, this version uses weights instead
@@ -49,6 +52,11 @@ public class EffectWeightedRandomList extends AbstractEffect
 		{
 			super(weight);
 			this.effect = eff;
+		}
+
+		public WeightedEffect()
+		{
+			super(1);
 		}
 
 		/**
@@ -71,6 +79,50 @@ public class EffectWeightedRandomList extends AbstractEffect
 		public void getDescription(List<String> list)
 		{
 			effect.getDescription(list);
+		}
+
+		protected void readFromNBT(NBTTagCompound data)
+		{
+			this.itemWeight = data.getInteger("item_weight");
+			if (data.hasKey("effect"))
+			{
+				this.effect = CoreRegistry.instance().getEffectsRegistry().loadEffectFromNBT(data, "effect");
+			}
+		}
+
+		@Override
+		public void readFromNBT(NBTTagCompound data, String name)
+		{
+			if (data.hasKey(name))
+			{
+				final NBTTagCompound effectData = data.getCompoundTag(name);
+				readFromNBT(effectData);
+			}
+			else
+			{
+				// LOG error
+			}
+		}
+
+		protected void writeToNBT(NBTTagCompound data)
+		{
+			data.setInteger("item_weight", itemWeight);
+			if (effect != null)
+			{
+				effect.writeToNBT(data, "effect");
+			}
+		}
+
+		@Override
+		public void writeToNBT(NBTTagCompound data, String name)
+		{
+			final NBTTagCompound target = new NBTTagCompound();
+			final String effectName = CoreRegistry.instance().getEffectsRegistry().getName(this.getClass());
+			// This is a VERY important field, this is how the effects will reload their correct class.
+			target.setString("__name__", effectName);
+			writeToNBT(target);
+
+			data.setTag(name, target);
 		}
 	}
 
@@ -217,5 +269,31 @@ public class EffectWeightedRandomList extends AbstractEffect
 				Describer.compactDescription(head, list, tempList);
 			}
 		}
+	}
+
+	@Override
+	protected void readFromNBT(NBTTagCompound data)
+	{
+		effects.clear();
+		final List<IEffect> list = new ArrayList<IEffect>();
+		NBTHelper.loadEffectsList(list, data);
+		for (IEffect effect : list)
+		{
+			if (effect instanceof WeightedEffect)
+			{
+				effects.add((WeightedEffect)effect);
+			}
+		}
+	}
+
+	@Override
+	protected void writeToNBT(NBTTagCompound data)
+	{
+		final List<IEffect> list = new ArrayList<IEffect>();
+		for (IEffect effect : effects)
+		{
+			list.add(effect);
+		}
+		NBTHelper.writeEffectsList(data, list);
 	}
 }

--- a/src/java/growthcraft/api/core/effect/EffectWeightedRandomList.java
+++ b/src/java/growthcraft/api/core/effect/EffectWeightedRandomList.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 IceDragon200
+ * Copyright (c) 2015, 2016 IceDragon200
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -39,7 +39,7 @@ import net.minecraft.util.WeightedRandom;
  * A variation of the EffectRandomList, this version uses weights instead
  * linear distribution.
  */
-public class EffectWeightedRandomList implements IEffect
+public class EffectWeightedRandomList extends AbstractEffect
 {
 	public static class WeightedEffect extends WeightedRandom.Item implements IEffect
 	{

--- a/src/java/growthcraft/api/core/effect/IEffect.java
+++ b/src/java/growthcraft/api/core/effect/IEffect.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 IceDragon200
+ * Copyright (c) 2015, 2016 IceDragon200
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -26,6 +26,7 @@ package growthcraft.api.core.effect;
 import java.util.Random;
 
 import growthcraft.api.core.description.IDescribable;
+import growthcraft.api.core.nbt.INBTSerializable;
 
 import net.minecraft.world.World;
 import net.minecraft.entity.Entity;
@@ -35,7 +36,7 @@ import net.minecraft.entity.Entity;
  * Its meant to solve the problem with constructing complex item effects,
  * where data along just won't cut it.
  */
-public interface IEffect extends IDescribable
+public interface IEffect extends IDescribable, INBTSerializable
 {
 	/**
 	 * This method is called when the effect needs to be applied to the

--- a/src/java/growthcraft/api/core/effect/IPotionEffectFactory.java
+++ b/src/java/growthcraft/api/core/effect/IPotionEffectFactory.java
@@ -26,6 +26,7 @@ package growthcraft.api.core.effect;
 import java.util.Random;
 
 import growthcraft.api.core.description.IDescribable;
+import growthcraft.api.core.nbt.INBTSerializable;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.potion.PotionEffect;
@@ -35,7 +36,7 @@ import net.minecraft.world.World;
  * Objects that implement this interface are expected to create PotionEffects
  * given certain parameters
  */
-public interface IPotionEffectFactory extends IDescribable
+public interface IPotionEffectFactory extends IDescribable, INBTSerializable
 {
 	PotionEffect createPotionEffect(World world, Entity entity, Random random, Object data);
 }

--- a/src/java/growthcraft/api/core/effect/SimplePotionEffectFactory.java
+++ b/src/java/growthcraft/api/core/effect/SimplePotionEffectFactory.java
@@ -26,9 +26,11 @@ package growthcraft.api.core.effect;
 import java.util.Random;
 import java.util.List;
 
+import growthcraft.api.core.CoreRegistry;
 import growthcraft.api.core.description.Describer;
 
 import net.minecraft.entity.Entity;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.potion.PotionEffect;
 import net.minecraft.world.World;
 
@@ -71,5 +73,45 @@ public class SimplePotionEffectFactory implements IPotionEffectFactory
 	{
 		final PotionEffect pe = createPotionEffect(null, null, null, null);
 		Describer.getPotionEffectDescription(list, pe);
+	}
+
+	private void readFromNBT(NBTTagCompound data)
+	{
+		this.id = data.getInteger("id");
+		this.time = data.getInteger("time");
+		this.level = data.getInteger("level");
+	}
+
+	@Override
+	public void readFromNBT(NBTTagCompound data, String name)
+	{
+		if (data.hasKey(name))
+		{
+			final NBTTagCompound subData = data.getCompoundTag(name);
+			readFromNBT(subData);
+		}
+		else
+		{
+			// LOG error
+		}
+	}
+
+	private void writeToNBT(NBTTagCompound data)
+	{
+		data.setInteger("id", getID());
+		data.setInteger("time", getTime());
+		data.setInteger("level", getLevel());
+	}
+
+	@Override
+	public void writeToNBT(NBTTagCompound data, String name)
+	{
+		final NBTTagCompound target = new NBTTagCompound();
+		final String factoryName = CoreRegistry.instance().getPotionEffectFactoryRegistry().getName(this.getClass());
+
+		target.setString("__name__", factoryName);
+		writeToNBT(target);
+
+		data.setTag(name, target);
 	}
 }

--- a/src/java/growthcraft/api/core/nbt/INBTSerializable.java
+++ b/src/java/growthcraft/api/core/nbt/INBTSerializable.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 IceDragon200
+ * Copyright (c) 2015, 2016 IceDragon200
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,12 +21,12 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package growthcraft.core.common.nbt;
+package growthcraft.api.core.nbt;
 
 import net.minecraft.nbt.NBTTagCompound;
 
-public interface INbtSerializable
+public interface INBTSerializable
 {
-	void writeToNBT(NBTTagCompound data, String name);
 	void readFromNBT(NBTTagCompound data, String name);
+	void writeToNBT(NBTTagCompound data, String name);
 }

--- a/src/java/growthcraft/api/core/nbt/NBTHelper.java
+++ b/src/java/growthcraft/api/core/nbt/NBTHelper.java
@@ -23,6 +23,10 @@
  */
 package growthcraft.api.core.nbt;
 
+import java.util.List;
+
+import growthcraft.api.core.CoreRegistry;
+import growthcraft.api.core.effect.IEffect;
 import growthcraft.api.core.util.ConstID;
 
 import net.minecraft.item.ItemStack;
@@ -134,5 +138,31 @@ public class NBTHelper
 	public static NBTTagCompound writeItemStackToNBT(ItemStack itemStack)
 	{
 		return writeItemStackToNBT(itemStack, new NBTTagCompound());
+	}
+
+	public static NBTTagCompound writeEffectsList(NBTTagCompound data, List<IEffect> list)
+	{
+		data.setInteger("size", list.size());
+		final NBTTagList effectsList = new NBTTagList();
+		for (IEffect effect : list)
+		{
+			final NBTTagCompound item = new NBTTagCompound();
+			effect.writeToNBT(item, "value");
+			effectsList.appendTag(item);
+		}
+		data.setTag("effects", effectsList);
+		return data;
+	}
+
+	public static void loadEffectsList(List<IEffect> list, NBTTagCompound data)
+	{
+		final int size = data.getInteger("size");
+		final NBTTagList effectsList = (NBTTagList)data.getTag("effects");
+		for (int i = 0; i < size; ++i)
+		{
+			final NBTTagCompound effectData = effectsList.getCompoundTagAt(i);
+			final IEffect effect = CoreRegistry.instance().getEffectsRegistry().loadEffectFromNBT(effectData, "value");
+			list.add(effect);
+		}
 	}
 }

--- a/src/java/growthcraft/api/core/nbt/NBTHelper.java
+++ b/src/java/growthcraft/api/core/nbt/NBTHelper.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 IceDragon200
+ * Copyright (c) 2015, 2016 IceDragon200
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,9 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package growthcraft.core.util;
+package growthcraft.api.core.nbt;
+
+import growthcraft.api.core.util.ConstID;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;

--- a/src/java/growthcraft/api/core/package-info.java
+++ b/src/java/growthcraft/api/core/package-info.java
@@ -1,4 +1,4 @@
-@API(apiVersion="2.4", owner="Growthcraft", provides="GrowthcraftAPI|Core")
+@API(apiVersion="2.4.1", owner="Growthcraft", provides="GrowthcraftAPI|Core")
 package growthcraft.api.core;
 
 import cpw.mods.fml.common.API;

--- a/src/java/growthcraft/api/core/util/ConstID.java
+++ b/src/java/growthcraft/api/core/util/ConstID.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2015 IceDragon200
+ * Copyright (c) 2015, 2016 IceDragon200
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package growthcraft.core.util;
+package growthcraft.api.core.util;
 
 /**
  * Place any "Magic Numbers" in this class, so we don't have to play the

--- a/src/java/growthcraft/bees/integration/waila/BeesDataProvider.java
+++ b/src/java/growthcraft/bees/integration/waila/BeesDataProvider.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import growthcraft.bees.common.tileentity.TileEntityBeeBox;
 import growthcraft.bees.util.TagFormatterBeeBox;
-import growthcraft.core.util.NBTHelper;
+import growthcraft.api.core.nbt.NBTHelper;
 
 import cpw.mods.fml.common.Optional;
 

--- a/src/java/growthcraft/cellar/common/tileentity/device/DeviceProgressive.java
+++ b/src/java/growthcraft/cellar/common/tileentity/device/DeviceProgressive.java
@@ -25,11 +25,12 @@ package growthcraft.cellar.common.tileentity.device;
 
 import io.netty.buffer.ByteBuf;
 
+import growthcraft.api.core.nbt.INBTSerializable;
 import growthcraft.cellar.common.tileentity.TileEntityCellarDevice;
 
 import net.minecraft.nbt.NBTTagCompound;
 
-public class DeviceProgressive extends DeviceBase
+public class DeviceProgressive extends DeviceBase implements INBTSerializable
 {
 	protected int time;
 	protected int timeMax;
@@ -100,9 +101,9 @@ public class DeviceProgressive extends DeviceBase
 	 */
 	public void readFromNBT(NBTTagCompound data, String name)
 	{
-		final NBTTagCompound list = data.getCompoundTag(name);
-		if (list != null)
+		if (data.hasKey(name))
 		{
+			final NBTTagCompound list = data.getCompoundTag(name);
 			readFromNBT(list);
 		}
 		else

--- a/src/java/growthcraft/cellar/integration/waila/CellarDataProvider.java
+++ b/src/java/growthcraft/cellar/integration/waila/CellarDataProvider.java
@@ -12,8 +12,8 @@ import growthcraft.cellar.util.TagFormatterBrewKettle;
 import growthcraft.cellar.util.TagFormatterFermentBarrel;
 import growthcraft.cellar.util.TagFormatterFermentJar;
 import growthcraft.cellar.util.TagFormatterFruitPress;
-import growthcraft.core.util.ConstID;
-import growthcraft.core.util.NBTHelper;
+import growthcraft.api.core.util.ConstID;
+import growthcraft.api.core.nbt.NBTHelper;
 import growthcraft.core.util.TagFormatterFluidHandler;
 
 import cpw.mods.fml.common.Optional;

--- a/src/java/growthcraft/cellar/util/TagFormatterFermentBarrel.java
+++ b/src/java/growthcraft/cellar/util/TagFormatterFermentBarrel.java
@@ -3,7 +3,7 @@ package growthcraft.cellar.util;
 import java.util.List;
 
 import growthcraft.api.core.i18n.GrcI18n;
-import growthcraft.core.util.ConstID;
+import growthcraft.api.core.util.ConstID;
 import growthcraft.core.util.ITagFormatter;
 import growthcraft.core.util.TagFormatterItem;
 

--- a/src/java/growthcraft/core/common/inventory/GrcInternalInventory.java
+++ b/src/java/growthcraft/core/common/inventory/GrcInternalInventory.java
@@ -23,9 +23,9 @@
  */
 package growthcraft.core.common.inventory;
 
-import growthcraft.core.util.NBTHelper;
+import growthcraft.nbt.core.nbt.NBTHelper;
 import growthcraft.core.util.ItemUtils;
-import growthcraft.core.common.nbt.INbtSerializable;
+import growthcraft.api.core.nbt.INBTSerializable;
 
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.inventory.IInventory;
@@ -33,7 +33,7 @@ import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagList;
 import net.minecraft.nbt.NBTTagCompound;
 
-public class GrcInternalInventory implements IInventory, INbtSerializable
+public class GrcInternalInventory implements IInventory, INBTSerializable
 {
 	public static final int WILDCARD_SLOT = -1;
 

--- a/src/java/growthcraft/core/common/inventory/GrcInternalInventory.java
+++ b/src/java/growthcraft/core/common/inventory/GrcInternalInventory.java
@@ -23,7 +23,7 @@
  */
 package growthcraft.core.common.inventory;
 
-import growthcraft.nbt.core.nbt.NBTHelper;
+import growthcraft.api.core.nbt.NBTHelper;
 import growthcraft.core.util.ItemUtils;
 import growthcraft.api.core.nbt.INBTSerializable;
 

--- a/src/java/growthcraft/core/util/TagFormatterFluidHandler.java
+++ b/src/java/growthcraft/core/util/TagFormatterFluidHandler.java
@@ -26,6 +26,7 @@ package growthcraft.core.util;
 import java.util.List;
 
 import growthcraft.api.core.i18n.GrcI18n;
+import growthcraft.api.core.util.ConstID;
 
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.nbt.NBTTagList;

--- a/src/java/growthcraft/core/util/TagFormatterItem.java
+++ b/src/java/growthcraft/core/util/TagFormatterItem.java
@@ -26,6 +26,7 @@ package growthcraft.core.util;
 import java.util.List;
 
 import growthcraft.api.core.i18n.GrcI18n;
+import growthcraft.api.core.util.ConstID;
 
 import net.minecraft.item.ItemStack;
 import net.minecraft.nbt.NBTTagCompound;

--- a/src/test/java/growthcraft/api/core/effect/TestEffect.java
+++ b/src/test/java/growthcraft/api/core/effect/TestEffect.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import net.minecraft.entity.Entity;
 import net.minecraft.world.World;
+import net.minecraft.nbt.NBTTagCompound;
 
 /**
  * Test Effect, use this as apart of larger effects, and check if it was touched.
@@ -22,4 +23,7 @@ public class TestEffect implements IEffect
 	{
 		list.add("TestEffect");
 	}
+
+	public void readFromNBT(NBTTagCompound data, String name) {}
+	public void writeToNBT(NBTTagCompound data, String name) {}
 }


### PR DESCRIPTION
You can poke your eyes out now.

I wanted to figure out if its possible to serialize the Effects system.

Conclusion, it can be done, therefore its possible to expose it to the user, the question is: 
How should the API even look!?

The second issue is converting the NBT data to JSON and vice versa.

Anyway, this is the first step to getting effects into the user hands, this also serves as a starting point for serializable all of Growthcraft's registries and so forth.

I'm planning to synchronize server and client registries, so user's don't have to have matching configs when they join a server, but that's in the future.
