### PR TITLE
Bees: Fixed oredict typo

### DIFF
--- a/src/java/growthcraft/bees/init/GrcBeesItems.java
+++ b/src/java/growthcraft/bees/init/GrcBeesItems.java
@@ -81,7 +81,7 @@ public class GrcBeesItems extends GrcModuleBase
 	public void init()
 	{
 		OreDictionary.registerOre("materialWax", beesWax.getItem());
-		OreDictionary.registerOre("materialPressedWax", beesWax.getItem());
+		OreDictionary.registerOre("materialPressedwax", beesWax.getItem());
 		OreDictionary.registerOre("materialBeeswax", beesWax.getItem());
 		OreDictionary.registerOre("materialBeeswaxBlack", EnumBeesWax.BLACK.asStack());
 		OreDictionary.registerOre("materialBeeswaxRed", EnumBeesWax.RED.asStack());


### PR DESCRIPTION
0d 0a 76 6b 6e 65 20 6f 64 6e 7a 20 79 6b 6e 20 79 74 61 72 65 65 74 20 64 6d 20 79 6b 6e 20 64 65 6e 20 71 6e 72 61 6a 65 6c 20 79 6b 6e 20 6e 74 6e 20 64 6d 20 6b 64 61 78 7a 20 6e 65 6f

This fixes a typo with the pressed wax entry, allowing for support for harvestcraft candle recipes.
