### PR TITLE
2.6.1 Changes

### DIFF
--- a/src/java/growthcraft/apples/init/GrcApplesFluids.java
+++ b/src/java/growthcraft/apples/init/GrcApplesFluids.java
@@ -55,6 +55,7 @@ public class GrcApplesFluids extends GrcModuleBase
 		}
 		BoozeRegistryHelper.initializeBooze(appleCiderBooze, appleCiderFluids, appleCiderBuckets);
 		BoozeRegistryHelper.setBoozeFoodStats(appleCiderBooze, 1, -0.3f);
+		BoozeRegistryHelper.setBoozeFoodStats(appleCiderBooze[0], 1, 0.3f);
 
 		appleCiderBooze[4].setColor(GrowthCraftApples.getConfig().silkenNectarColor);
 		appleCiderFluids[4].getBlock().refreshColor();

--- a/src/java/growthcraft/bees/init/GrcBeesFluids.java
+++ b/src/java/growthcraft/bees/init/GrcBeesFluids.java
@@ -74,6 +74,7 @@ public class GrcBeesFluids extends GrcModuleBase
 		}
 		BoozeRegistryHelper.initializeBooze(honeyMeadBooze, honeyMeadFluids, honeyMeadBuckets);
 		BoozeRegistryHelper.setBoozeFoodStats(honeyMeadBooze, 1, -0.45f);
+		BoozeRegistryHelper.setBoozeFoodStats(honeyMeadBooze[0], 1, 0.45f);
 		honeyMeadBottle = new ItemDefinition(new ItemBoozeBottle(honeyMeadBooze));
 
 		if (honey != null)

--- a/src/java/growthcraft/cellar/common/tileentity/TileEntityBrewKettle.java
+++ b/src/java/growthcraft/cellar/common/tileentity/TileEntityBrewKettle.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 
 import io.netty.buffer.ByteBuf;
 
-import growthcraft.api.core.fluids.FluidUtils;
 import growthcraft.cellar.common.fluids.CellarTank;
 import growthcraft.cellar.common.tileentity.device.BrewKettle;
 import growthcraft.cellar.GrowthCraftCellar;
@@ -30,10 +29,6 @@ public class TileEntityBrewKettle extends TileEntityCellarDevice implements ITil
 	{
 		TIME,
 		TIME_MAX,
-		TANK1_FLUID_ID,
-		TANK1_FLUID_AMOUNT,
-		TANK2_FLUID_ID,
-		TANK2_FLUID_AMOUNT,
 		HEAT_AMOUNT;
 
 		public static final List<BrewKettleDataID> VALUES = Arrays.asList(values());
@@ -194,22 +189,6 @@ public class TileEntityBrewKettle extends TileEntityCellarDevice implements ITil
 			case TIME_MAX:
 				brewKettle.setTimeMax(v);
 				break;
-			case TANK1_FLUID_ID:
-			{
-				final FluidStack result = FluidUtils.replaceFluidStack(v, getFluidStack(0));
-				if (result != null) getFluidTank(0).setFluid(result);
-			}	break;
-			case TANK1_FLUID_AMOUNT:
-				getFluidTank(0).setFluid(FluidUtils.updateFluidStackAmount(getFluidStack(0), v));
-				break;
-			case TANK2_FLUID_ID:
-			{
-				final FluidStack result = FluidUtils.replaceFluidStack(v, getFluidStack(1));
-				if (result != null) getFluidTank(1).setFluid(result);
-			}	break;
-			case TANK2_FLUID_AMOUNT:
-				getFluidTank(1).setFluid(FluidUtils.updateFluidStackAmount(getFluidStack(1), v));
-				break;
 			case HEAT_AMOUNT:
 				brewKettle.setHeatMultiplier((float)v / (float)0x7FFF);
 				break;
@@ -224,12 +203,6 @@ public class TileEntityBrewKettle extends TileEntityCellarDevice implements ITil
 		super.sendGUINetworkData(container, iCrafting);
 		iCrafting.sendProgressBarUpdate(container, BrewKettleDataID.TIME.ordinal(), (int)brewKettle.getTime());
 		iCrafting.sendProgressBarUpdate(container, BrewKettleDataID.TIME_MAX.ordinal(), (int)brewKettle.getTimeMax());
-		FluidStack fluid = getFluidStack(0);
-		iCrafting.sendProgressBarUpdate(container, BrewKettleDataID.TANK1_FLUID_ID.ordinal(), fluid != null ? fluid.getFluidID() : 0);
-		iCrafting.sendProgressBarUpdate(container, BrewKettleDataID.TANK1_FLUID_AMOUNT.ordinal(), fluid != null ? fluid.amount : 0);
-		fluid = getFluidStack(1);
-		iCrafting.sendProgressBarUpdate(container, BrewKettleDataID.TANK2_FLUID_ID.ordinal(), fluid != null ? fluid.getFluidID() : 0);
-		iCrafting.sendProgressBarUpdate(container, BrewKettleDataID.TANK2_FLUID_AMOUNT.ordinal(), fluid != null ? fluid.amount : 0);
 		iCrafting.sendProgressBarUpdate(container, BrewKettleDataID.HEAT_AMOUNT.ordinal(), (int)(brewKettle.getHeatMultiplier() * 0x7FFF));
 	}
 

--- a/src/java/growthcraft/cellar/common/tileentity/TileEntityCellarDevice.java
+++ b/src/java/growthcraft/cellar/common/tileentity/TileEntityCellarDevice.java
@@ -23,21 +23,63 @@
  */
 package growthcraft.cellar.common.tileentity;
 
+import growthcraft.api.core.fluids.FluidUtils;
 import growthcraft.core.common.tileentity.GrcTileEntityDeviceBase;
 import growthcraft.core.common.tileentity.IGuiNetworkSync;
 
 import net.minecraft.inventory.Container;
 import net.minecraft.inventory.ICrafting;
+import net.minecraftforge.fluids.FluidStack;
+import net.minecraftforge.fluids.FluidTank;
 
 public abstract class TileEntityCellarDevice extends GrcTileEntityDeviceBase implements IGuiNetworkSync
 {
 	@Override
 	public void receiveGUINetworkData(int id, int v)
 	{
+		// 50 is more than generous right?
+		if (id >= 50)
+		{
+			final int tankIndex = (id - 50) / 3;
+			switch ((id - 50) % 3)
+			{
+				// Fluid ID
+				case 0:
+				{
+					final FluidStack result = FluidUtils.replaceFluidStack(v, getFluidStack(tankIndex));
+					if (result != null) getFluidTank(tankIndex).setFluid(result);
+				} break;
+				// Fluid amounts CAN exceed a 16bit integer, in order to handle the capacity, the value is split across 2 data points, by high and low bytes
+				// Fluid Amount (LOW Bytes)
+				case 1:
+				{
+					final int t = getFluidAmount(tankIndex);
+					setFluidStack(tankIndex, FluidUtils.updateFluidStackAmount(getFluidStack(tankIndex), (t & 0xFFFF0000) | v));
+				} break;
+				// Fluid Amount (HIGH Bytes)
+				case 2:
+				{
+					final int t = getFluidAmount(tankIndex);
+					getFluidTank(tankIndex).setFluid(FluidUtils.updateFluidStackAmount(getFluidStack(tankIndex), (t & 0xFFFF) | (v << 16)));
+				} break;
+				default:
+					break;
+			}
+		}
 	}
 
 	@Override
 	public void sendGUINetworkData(Container container, ICrafting iCrafting)
 	{
+		int i = 0;
+		for (FluidTank tank : getFluidTanks())
+		{
+			final int offset = 50 + i * 3;
+			final FluidStack fluid = getFluidStack(i);
+			iCrafting.sendProgressBarUpdate(container, offset, fluid != null ? fluid.getFluidID() : 0);
+			iCrafting.sendProgressBarUpdate(container, offset + 1, fluid != null ? (fluid.amount & 0xFFFF) : 0);
+			iCrafting.sendProgressBarUpdate(container, offset + 2, fluid != null ? ((fluid.amount >> 16) & 0xFFFF) : 0);
+			i++;
+		}
 	}
 }

--- a/src/java/growthcraft/cellar/common/tileentity/TileEntityCultureJar.java
+++ b/src/java/growthcraft/cellar/common/tileentity/TileEntityCultureJar.java
@@ -25,7 +25,6 @@ package growthcraft.cellar.common.tileentity;
 
 import java.io.IOException;
 
-import growthcraft.api.core.fluids.FluidUtils;
 import growthcraft.cellar.common.fluids.CellarTank;
 import growthcraft.cellar.common.tileentity.component.TileHeatingComponent;
 import growthcraft.cellar.common.tileentity.device.CultureGenerator;
@@ -56,8 +55,6 @@ public class TileEntityCultureJar extends TileEntityCellarDevice implements ITil
 		YEAST_GEN_TIME_MAX,
 		CULTURE_GEN_TIME,
 		CULTURE_GEN_TIME_MAX,
-		TANK_FLUID_ID,
-		TANK_FLUID_AMOUNT,
 		HEAT_AMOUNT,
 		UNKNOWN;
 
@@ -67,8 +64,6 @@ public class TileEntityCultureJar extends TileEntityCellarDevice implements ITil
 			YEAST_GEN_TIME_MAX,
 			CULTURE_GEN_TIME,
 			CULTURE_GEN_TIME_MAX,
-			TANK_FLUID_ID,
-			TANK_FLUID_AMOUNT,
 			HEAT_AMOUNT
 		};
 
@@ -236,13 +231,6 @@ public class TileEntityCultureJar extends TileEntityCellarDevice implements ITil
 			case CULTURE_GEN_TIME_MAX:
 				cultureGen.setTimeMax(v);
 				break;
-			case TANK_FLUID_ID:
-				final FluidStack result = FluidUtils.replaceFluidStack(v, getFluidStack(0));
-				if (result != null) getFluidTank(0).setFluid(result);
-				break;
-			case TANK_FLUID_AMOUNT:
-				getFluidTank(0).setFluid(FluidUtils.updateFluidStackAmount(getFluidStack(0), v));
-				break;
 			case HEAT_AMOUNT:
 				heatComponent.setHeatMultiplier((float)v / (float)0x7FFF);
 				break;
@@ -260,9 +248,6 @@ public class TileEntityCultureJar extends TileEntityCellarDevice implements ITil
 		iCrafting.sendProgressBarUpdate(container, CultureJarDataId.YEAST_GEN_TIME_MAX.ordinal(), yeastGen.getTimeMax());
 		iCrafting.sendProgressBarUpdate(container, CultureJarDataId.CULTURE_GEN_TIME.ordinal(), cultureGen.getTime());
 		iCrafting.sendProgressBarUpdate(container, CultureJarDataId.CULTURE_GEN_TIME_MAX.ordinal(), cultureGen.getTimeMax());
-		final FluidStack fluid = getFluidStack(0);
-		iCrafting.sendProgressBarUpdate(container, CultureJarDataId.TANK_FLUID_ID.ordinal(), fluid != null ? fluid.getFluidID() : 0);
-		iCrafting.sendProgressBarUpdate(container, CultureJarDataId.TANK_FLUID_AMOUNT.ordinal(), fluid != null ? fluid.amount : 0);
 		iCrafting.sendProgressBarUpdate(container, CultureJarDataId.HEAT_AMOUNT.ordinal(), (int)(heatComponent.getHeatMultiplier() * 0x7FFF));
 	}
 

--- a/src/java/growthcraft/cellar/common/tileentity/TileEntityFermentBarrel.java
+++ b/src/java/growthcraft/cellar/common/tileentity/TileEntityFermentBarrel.java
@@ -34,11 +34,9 @@ public class TileEntityFermentBarrel extends TileEntityCellarDevice implements I
 	{
 		TIME,
 		TIME_MAX,
-		TANK_FLUID_ID,
-		TANK_FLUID_AMOUNT,
 		UNKNOWN;
 
-		public static final FermentBarrelDataID[] VALID = new FermentBarrelDataID[] { TIME, TIME_MAX, TANK_FLUID_ID, TANK_FLUID_AMOUNT };
+		public static final FermentBarrelDataID[] VALID = new FermentBarrelDataID[] { TIME, TIME_MAX };
 
 		public static FermentBarrelDataID fromInt(int i)
 		{
@@ -318,8 +316,6 @@ public class TileEntityFermentBarrel extends TileEntityCellarDevice implements I
 	public void receiveGUINetworkData(int id, int v)
 	{
 		super.receiveGUINetworkData(id, v);
-		// Debugging
-		//GrowthCraftCellar.getLogger().info("Updating Network data id=%d value=%d", id, v);
 		switch (FermentBarrelDataID.fromInt(id))
 		{
 			case TIME:
@@ -327,13 +323,6 @@ public class TileEntityFermentBarrel extends TileEntityCellarDevice implements I
 				break;
 			case TIME_MAX:
 				this.timemax = v;
-				break;
-			case TANK_FLUID_ID:
-				final FluidStack result = FluidUtils.replaceFluidStack(v, getFluidStack(0));
-				if (result != null) getFluidTank(0).setFluid(result);
-				break;
-			case TANK_FLUID_AMOUNT:
-				getFluidTank(0).setFluid(FluidUtils.updateFluidStackAmount(getFluidStack(0), v));
 				break;
 			default:
 				// should warn about invalid Data ID
@@ -347,9 +336,6 @@ public class TileEntityFermentBarrel extends TileEntityCellarDevice implements I
 		super.sendGUINetworkData(container, iCrafting);
 		iCrafting.sendProgressBarUpdate(container, FermentBarrelDataID.TIME.ordinal(), time);
 		iCrafting.sendProgressBarUpdate(container, FermentBarrelDataID.TIME_MAX.ordinal(), getTimeMax());
-		final FluidStack fluid = getFluidStack(0);
-		iCrafting.sendProgressBarUpdate(container, FermentBarrelDataID.TANK_FLUID_ID.ordinal(), fluid != null ? fluid.getFluidID() : 0);
-		iCrafting.sendProgressBarUpdate(container, FermentBarrelDataID.TANK_FLUID_AMOUNT.ordinal(), fluid != null ? fluid.amount : 0);
 	}
 
 	@EventHandler(type=EventHandler.EventType.NETWORK_READ)

--- a/src/java/growthcraft/cellar/common/tileentity/TileEntityFruitPress.java
+++ b/src/java/growthcraft/cellar/common/tileentity/TileEntityFruitPress.java
@@ -1,6 +1,5 @@
 package growthcraft.cellar.common.tileentity;
 
-import growthcraft.api.core.fluids.FluidUtils;
 import growthcraft.cellar.common.fluids.CellarTank;
 import growthcraft.cellar.common.tileentity.device.FruitPress;
 import growthcraft.cellar.GrowthCraftCellar;
@@ -22,8 +21,6 @@ public class TileEntityFruitPress extends TileEntityCellarDevice implements ITil
 	{
 		public static final int TIME = 0;
 		public static final int TIME_MAX = 1;
-		public static final int TANK_FLUID_ID = 2;
-		public static final int TANK_FLUID_AMOUNT = 3;
 
 		private FruitPressDataID() {}
 	}
@@ -165,13 +162,6 @@ public class TileEntityFruitPress extends TileEntityCellarDevice implements ITil
 			case FruitPressDataID.TIME_MAX:
 				fruitPress.setTimeMax(v);
 				break;
-			case FruitPressDataID.TANK_FLUID_ID:
-				final FluidStack result = FluidUtils.replaceFluidStack(v, getFluidStack(0));
-				if (result != null) getFluidTank(0).setFluid(result);
-				break;
-			case FruitPressDataID.TANK_FLUID_AMOUNT:
-				getFluidTank(0).setFluid(FluidUtils.updateFluidStackAmount(getFluidStack(0), v));
-				break;
 			default:
 				// should warn about invalid Data ID
 				break;
@@ -184,9 +174,6 @@ public class TileEntityFruitPress extends TileEntityCellarDevice implements ITil
 		super.sendGUINetworkData(container, iCrafting);
 		iCrafting.sendProgressBarUpdate(container, FruitPressDataID.TIME, fruitPress.getTime());
 		iCrafting.sendProgressBarUpdate(container, FruitPressDataID.TIME_MAX, fruitPress.getTimeMax());
-		final FluidStack fluid = getFluidStack(0);
-		iCrafting.sendProgressBarUpdate(container, FruitPressDataID.TANK_FLUID_ID, fluid != null ? fluid.getFluidID() : 0);
-		iCrafting.sendProgressBarUpdate(container, FruitPressDataID.TANK_FLUID_AMOUNT, fluid != null ? fluid.amount : 0);
 	}
 
 	@Override

--- a/src/java/growthcraft/grapes/init/GrcGrapesFluids.java
+++ b/src/java/growthcraft/grapes/init/GrcGrapesFluids.java
@@ -69,6 +69,8 @@ public class GrcGrapesFluids extends GrcModuleBase
 		}
 		BoozeRegistryHelper.initializeBooze(grapeWineBooze, grapeWineFluids, grapeWineBuckets);
 		BoozeRegistryHelper.setBoozeFoodStats(grapeWineBooze, 1, -0.3f);
+		BoozeRegistryHelper.setBoozeFoodStats(grapeWineBooze[0], 1, 0.3f);
+
 		grapeWineBooze[4].setColor(GrowthCraftGrapes.getConfig().ambrosiaColor);
 		grapeWineFluids[4].getBlock().refreshColor();
 		grapeWineBooze[5].setColor(GrowthCraftGrapes.getConfig().portWineColor);

--- a/src/java/growthcraft/hops/init/GrcHopsFluids.java
+++ b/src/java/growthcraft/hops/init/GrcHopsFluids.java
@@ -73,6 +73,7 @@ public class GrcHopsFluids extends GrcModuleBase
 		}
 		BoozeRegistryHelper.initializeBooze(lagerBooze, lagerFluids, lagerBuckets);
 		BoozeRegistryHelper.setBoozeFoodStats(lagerBooze, 1, -0.6f);
+		BoozeRegistryHelper.setBoozeFoodStats(lagerBooze[0], 1, 0.3f);
 
 		this.lager = new ItemDefinition(new ItemBoozeBottle(lagerBooze));
 
@@ -86,6 +87,8 @@ public class GrcHopsFluids extends GrcModuleBase
 		}
 		BoozeRegistryHelper.initializeBooze(hopAleBooze, hopAleFluids, hopAleBuckets);
 		BoozeRegistryHelper.setBoozeFoodStats(hopAleBooze, 1, -0.6f);
+		BoozeRegistryHelper.setBoozeFoodStats(hopAleBooze[0], 1, 0.3f);
+		BoozeRegistryHelper.setBoozeFoodStats(hopAleBooze[4], 1, 0.3f);
 
 		this.hopAle = new ItemDefinition(new ItemBoozeBottle(hopAleBooze));
 	}

--- a/src/java/growthcraft/milk/init/GrcMilkFluids.java
+++ b/src/java/growthcraft/milk/init/GrcMilkFluids.java
@@ -114,6 +114,7 @@ public class GrcMilkFluids extends GrcModuleBase
 		}
 		BoozeRegistryHelper.initializeBooze(kumisFluids, kumisFluidBlocks, kumisFluidBuckets);
 		BoozeRegistryHelper.setBoozeFoodStats(kumisFluids, 1, -0.2f);
+		BoozeRegistryHelper.setBoozeFoodStats(kumisFluids[0], 1, 0.2f);
 		kumisFluids[5].setColor(GrowthCraftMilk.getConfig().poisonedKumisColor);
 		kumisFluidBlocks[5].getBlock().refreshColor();
 		for (BlockBoozeDefinition def : kumisFluidBlocks)

--- a/src/java/growthcraft/rice/init/GrcRiceFluids.java
+++ b/src/java/growthcraft/rice/init/GrcRiceFluids.java
@@ -70,6 +70,7 @@ public class GrcRiceFluids extends GrcModuleBase
 		}
 		BoozeRegistryHelper.initializeBooze(riceSakeBooze, riceSakeFluids, riceSakeBuckets);
 		BoozeRegistryHelper.setBoozeFoodStats(riceSakeBooze, 1, -0.6f);
+		BoozeRegistryHelper.setBoozeFoodStats(riceSakeBooze[0], 1, 0.2f);
 		riceSakeBooze[4].setColor(GrowthCraftRice.getConfig().riceSakeDivineColor);
 		riceSakeFluids[4].getBlock().refreshColor();
 		riceSake = new ItemDefinition(new ItemBoozeBottle(riceSakeBooze));


### PR DESCRIPTION
## Builds

**2016-06-08 @ 10:03:45 EST** 188f028 [2.6.0 - Download](https://dl.dropboxusercontent.com/u/72618186/minecraft/mods/growthcraft/2.6.0/growthcraft-1.7.10-2.6.0-complete--188f028.jar)

> #### Checksums
> 
> **MD5**: d43949bfe1fda5ed1618af2aed6c2985
> **SHA1**: 72839a6640a1a530470350c67cc57e474a63c8f3
> **SHA256**: 1a2429a866d7979dbb537d32d144d9e309621fba2d0ca2ddc6309714fa748dcf
> #### Changes
> - Fixes fluid amounts in cellar GUIs
## Changes
- 5119d53 Fixed Booze young variants reducing saturation (they should have increased it instead)
- 188f028 Fixed all cellar devices (Ferment Barrel, Brew Kettle, Culture Jar, Fruit Press) guis, fluid amounts over 65535 would cause wrap-around and other odd bugs.
