### PR TITLE
2.7.1 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Growthcraft
 ===========
 
 [![Minecraft Version](http://img.shields.io/minecraft/1.7.10.png?color=green)](https://minecraft.net/)
-[![Growthcraft Version](http://img.shields.io/growthcraft/2.6.3.png?color=green)](https://github.com/GrowthcraftCE/Growthcraft-1.7)
+[![Growthcraft Version](http://img.shields.io/growthcraft/2.7.0.png?color=green)](https://github.com/GrowthcraftCE/Growthcraft-1.7)
 [![Forge Version](http://img.shields.io/forge/10.13.4.1566.png?color=green)](http://files.minecraftforge.net/)
 [![Java Version](http://img.shields.io/java/7.png?color=green)](https://www.java.com/en/)
 [![Build Status](https://travis-ci.org/GrowthcraftCE/Growthcraft-1.7.svg?branch=master)](https://travis-ci.org/GrowthcraftCE/Growthcraft-1.7) 

--- a/src/java/growthcraft/bees/common/block/BlockBeeBox.java
+++ b/src/java/growthcraft/bees/common/block/BlockBeeBox.java
@@ -124,9 +124,6 @@ public class BlockBeeBox extends GrcBlockContainer
 		}
 	}
 
-	/************
-	 * TRIGGERS
-	 ************/
 	@Override
 	public boolean onBlockActivated(World world, int x, int y, int z, EntityPlayer player, int meta, float par7, float par8, float par9)
 	{
@@ -148,29 +145,6 @@ public class BlockBeeBox extends GrcBlockContainer
 	}
 
 	@Override
-	public void breakBlock(World world, int x, int y, int z, Block par5, int par6)
-	{
-		final TileEntityBeeBox te = (TileEntityBeeBox)world.getTileEntity(x, y, z);
-
-		if (te != null)
-		{
-			for (int index = 0; index < te.getSizeInventory(); ++index)
-			{
-				final ItemStack stack = te.getStackInSlot(index);
-
-				ItemUtils.spawnItemStack(world, x, y, z, stack, world.rand);
-			}
-
-			world.func_147453_f(x, y, z, par5);
-		}
-
-		super.breakBlock(world, x, y, z, par5, par6);
-	}
-
-	/************
-	 * CONDITIONS
-	 ************/
-	@Override
 	public boolean isSideSolid(IBlockAccess world, int x, int y, int z, ForgeDirection side)
 	{
 		return ForgeDirection.UP == side;
@@ -182,9 +156,6 @@ public class BlockBeeBox extends GrcBlockContainer
 		return new TileEntityBeeBox();
 	}
 
-	/************
-	 * DROPS
-	 ************/
 	@Override
 	public int damageDropped(int damage)
 	{
@@ -197,9 +168,6 @@ public class BlockBeeBox extends GrcBlockContainer
 		return 1;
 	}
 
-	/************
-	 * TEXTURES
-	 ************/
 	@SideOnly(Side.CLIENT)
 	protected void registerBeeBoxIcons(IIconRegister reg, String basename, int offset)
 	{
@@ -274,9 +242,6 @@ public class BlockBeeBox extends GrcBlockContainer
 		return icons;
 	}
 
-	/************
-	 * RENDERS
-	 ************/
 	@Override
 	public int getRenderType()
 	{
@@ -302,9 +267,6 @@ public class BlockBeeBox extends GrcBlockContainer
 		return true;
 	}
 
-	/************
-	 * BOXES
-	 ************/
 	@Override
 	public void setBlockBoundsForItemRender()
 	{
@@ -336,9 +298,6 @@ public class BlockBeeBox extends GrcBlockContainer
 		setBlockBoundsForItemRender();
 	}
 
-	/************
-	 * COMPARATOR
-	 ************/
 	@Override
 	public boolean hasComparatorInputOverride()
 	{
@@ -349,6 +308,10 @@ public class BlockBeeBox extends GrcBlockContainer
 	public int getComparatorInputOverride(World world, int x, int y, int z, int par5)
 	{
 		final TileEntityBeeBox te = (TileEntityBeeBox)world.getTileEntity(x, y, z);
-		return te.countHoney() * 15 / 27;
+		if (te != null)
+		{
+			return te.countHoney() * 15 / te.getHoneyCombMax();
+		}
+		return 0;
 	}
 }

--- a/src/java/growthcraft/bees/common/block/BlockBeeBox.java
+++ b/src/java/growthcraft/bees/common/block/BlockBeeBox.java
@@ -8,11 +8,9 @@ import growthcraft.bees.common.tileentity.TileEntityBeeBox;
 import growthcraft.bees.GrowthCraftBees;
 import growthcraft.core.common.block.GrcBlockContainer;
 import growthcraft.core.integration.minecraft.EnumMinecraftWoodType;
-import growthcraft.core.util.ItemUtils;
 
 import cpw.mods.fml.relauncher.Side;
 import cpw.mods.fml.relauncher.SideOnly;
-import net.minecraft.block.Block;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.creativetab.CreativeTabs;

--- a/src/java/growthcraft/bees/common/tileentity/TileEntityBeeBox.java
+++ b/src/java/growthcraft/bees/common/tileentity/TileEntityBeeBox.java
@@ -52,7 +52,11 @@ public class TileEntityBeeBox extends GrcTileInventoryBase implements IItemHandl
 	public void onInventoryChanged(IInventory inv, int index)
 	{
 		super.onInventoryChanged(inv, index);
-		if (index > 0)
+		if (index == 0)
+		{
+			markDirty();
+		}
+		else if (index > 0)
 		{
 			markDirtyAndUpdate();
 		}

--- a/src/java/growthcraft/core/common/inventory/GrcContainer.java
+++ b/src/java/growthcraft/core/common/inventory/GrcContainer.java
@@ -105,7 +105,7 @@ public class GrcContainer extends Container
 				merged |= mergeWithSlot(subSlot, stack);
 			}
 		}
-		return mergeItemStack(stack, start, end + 1, false);
+		return merged;
 	}
 
 	public boolean mergeWithPlayer(ItemStack stack)
@@ -179,10 +179,7 @@ public class GrcContainer extends Container
 			{
 				s.putStack((ItemStack)null);
 			}
-			else
-			{
-				s.onSlotChanged();
-			}
+			s.onSlotChanged();
 
 			if (stack.stackSize == itemstack.stackSize)
 			{

--- a/src/java/growthcraft/core/util/ItemUtils.java
+++ b/src/java/growthcraft/core/util/ItemUtils.java
@@ -190,7 +190,7 @@ public class ItemUtils
 
 	public static void spawnItemStack(World world, double x, double y, double z, ItemStack stack, Random random)
 	{
-		if (stack != null)
+		if (stack != null && stack.stackSize > 0)
 		{
 			final double f = random.nextDouble() * 0.8D + 0.1D;
 			final double f1 = random.nextDouble() * 0.8D + 0.1D;

--- a/tools/split_jars.rb
+++ b/tools/split_jars.rb
@@ -90,8 +90,12 @@ Dir.glob File.expand_path("../build/libs/growthcraft-*.jar", File.dirname(__FILE
         %(-C "#{dir}/content" grc_#{packname}_logo.png),
         %(-C "#{dir}/content" assets/grc#{packname})
       ]
-      # core requires the api as well -.-;
-      content << %(-C "#{dir}/content" growthcraft/api) if packname == 'core'
+      if packname == 'core'
+        # core requires the api as well -.-;
+        content << %(-C "#{dir}/content" growthcraft/api)
+        # also the buildcraft api
+        content << %(-C "#{dir}/content" buildcraft)
+      end
       cmd = %(jar #{vflag}cf build/packages/#{filename} ) + content.join(" ")
       sh cmd
     end


### PR DESCRIPTION
~~Nothing much changed here, I've only fixed our build tool to fix a broken 2.7.0 split jar release 3;~~

~~@Alatyami Quickly merge and release when you get the time :)~~
# 2.7.1 Changes

2.7.1, originally meant as a build fix, turned into a minor bug fix
## Disclaimer

We (Growthcraft CE Development Team), **will NOT be held responsible** for ANY damage incurred by using a **test build**, whether physical, mental or spirtual.
## Builds

**2016-10-14 @ 19:37:31 EST** 11e8158 [2.7.0 - Download](https://dl.dropboxusercontent.com/u/72618186/minecraft/mods/growthcraft/2.7.0/growthcraft-1.7.10-2.7.0-complete--11e8158.jar)

> #### Checksums
> 
> **MD5**: 2948fa1bcf926e16f62e5c97403ca6fb
> **SHA1**: a02c455ca20bfde4fdf1d7a71be64a2bbd854699
> **SHA256**: 135d2d15f2c24e8cb8bba22dd08494336b3dcd5e127911b543b4a6510994613f
> #### Changes
> - Fixes #425, (see Change Log for more details)
## Change Log
- Fixes #425 - An item duplication and event bug with the Bee Box, the item duplication was caused by double dropping the inventory contents (once by the Bee Box itself, and then again by the GrcBlockContainer scatterInventory)
- Includes the Buildrcraft IToolWrench Interface, fixes the ItemCrowbar missing error
