### PR TITLE
2.7.3 Release

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
       tzinfo (~> 1.1)
     colorize (0.7.7)
     i18n (0.7.0)
-    json (1.8.3)
+    json (1.8.6)
     minitest (5.8.4)
     thread_safe (0.3.5)
     tzinfo (1.2.2)
@@ -23,4 +23,4 @@ DEPENDENCIES
   colorize
 
 BUNDLED WITH
-   1.11.2
+   1.13.7

--- a/src/java/growthcraft/fishtrap/GrowthCraftFishTrap.java
+++ b/src/java/growthcraft/fishtrap/GrowthCraftFishTrap.java
@@ -94,26 +94,26 @@ public class GrowthCraftFishTrap
 		userBaitConfig.addDefault(new ItemStack(Items.rotten_flesh), 0.2f, 1.1f);
 
 		// Catch Groups
-		userCatchGroupConfig.addDefault("junk", 3, "Useless Stuff");
-		userCatchGroupConfig.addDefault("treasure", 5, "Fancy Stuff");
-		userCatchGroupConfig.addDefault("fish", 1, "Fishes");
-		userCatchGroupConfig.addDefault("mineral", 7, "Ingots and other metallic stuff");
-		userCatchGroupConfig.addDefault("legendary", 10, "Stuff you probably would never find on average");
+		userCatchGroupConfig.addDefault("junk", 7, "Useless Stuff");
+		userCatchGroupConfig.addDefault("treasure", 2, "Fancy Stuff");
+		userCatchGroupConfig.addDefault("fish", 20, "Fishes");
+		userCatchGroupConfig.addDefault("mineral", 3, "Ingots and other metallic stuff");
+		userCatchGroupConfig.addDefault("legendary", 1, "Stuff you probably would never find on average");
 
 		// Will use same chances as Fishing Rods
 		// Junk
-		userFishTrapConfig.addDefault("junk", new FishTrapEntry(new ItemStack(Items.leather_boots), 10).setDamage(0.9F));
-		userFishTrapConfig.addDefault("junk", new FishTrapEntry(new ItemStack(Items.leather), 10));
-		userFishTrapConfig.addDefault("junk", new FishTrapEntry(new ItemStack(Items.bone), 10));
-		userFishTrapConfig.addDefault("junk", new FishTrapEntry(new ItemStack(Items.potionitem), 10));
+		userFishTrapConfig.addDefault("junk", new FishTrapEntry(new ItemStack(Items.leather_boots), 5).setDamage(0.9F));
+		userFishTrapConfig.addDefault("junk", new FishTrapEntry(new ItemStack(Items.leather), 5));
+		userFishTrapConfig.addDefault("junk", new FishTrapEntry(new ItemStack(Items.bone), 5));
+		userFishTrapConfig.addDefault("junk", new FishTrapEntry(new ItemStack(Items.potionitem), 3));
 		userFishTrapConfig.addDefault("junk", new FishTrapEntry(new ItemStack(Items.string), 5));
 		userFishTrapConfig.addDefault("junk", new FishTrapEntry(new ItemStack(Items.fishing_rod), 2).setDamage(0.9F));
-		userFishTrapConfig.addDefault("junk", new FishTrapEntry(new ItemStack(Items.bowl), 10));
-		userFishTrapConfig.addDefault("junk", new FishTrapEntry(new ItemStack(Items.stick), 5));
-		userFishTrapConfig.addDefault("junk", new FishTrapEntry(new ItemStack(Items.dye, 10), 1));
-		userFishTrapConfig.addDefault("junk", new FishTrapEntry(new ItemStack(Items.rotten_flesh), 10));
+		userFishTrapConfig.addDefault("junk", new FishTrapEntry(new ItemStack(Items.bowl), 5));
+		userFishTrapConfig.addDefault("junk", new FishTrapEntry(new ItemStack(Items.stick), 10));
+		userFishTrapConfig.addDefault("junk", new FishTrapEntry(new ItemStack(Items.dye, 5), 1));
+		userFishTrapConfig.addDefault("junk", new FishTrapEntry(new ItemStack(Items.rotten_flesh), 5));
 		// Treasure
-		userFishTrapConfig.addDefault("treasure", new FishTrapEntry(new ItemStack(Blocks.waterlily), 1));
+		userFishTrapConfig.addDefault("treasure", new FishTrapEntry(new ItemStack(Blocks.waterlily), 3));
 		userFishTrapConfig.addDefault("treasure", new FishTrapEntry(new ItemStack(Items.name_tag), 1));
 		userFishTrapConfig.addDefault("treasure", new FishTrapEntry(new ItemStack(Items.saddle), 1));
 		userFishTrapConfig.addDefault("treasure", new FishTrapEntry(new ItemStack(Items.bow), 1).setDamage(0.25F).setEnchantable());

--- a/src/java/growthcraft/milk/common/block/BlockCheeseBlock.java
+++ b/src/java/growthcraft/milk/common/block/BlockCheeseBlock.java
@@ -47,6 +47,7 @@ import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
+import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.IIcon;
 import net.minecraft.util.MovingObjectPosition;
 import net.minecraft.world.IBlockAccess;
@@ -162,10 +163,14 @@ public class BlockCheeseBlock extends GrcBlockContainer
 			{
 				if (cheese.hasBlock())
 				{
-					final ItemStack stack = new ItemStack(item, 1, cheese.meta);
-					// This causes the NBT data to refresh
-					ib.getTileTagCompound(stack);
-					list.add(stack);
+					for (EnumCheeseStage stage : cheese.stages)
+					{
+						final ItemStack stack = new ItemStack(item, 1, cheese.meta);
+						// This causes the NBT data to refresh
+						final NBTTagCompound tag = ib.getTileTagCompound(stack);
+						stage.writeToNBT(tag);
+						list.add(stack);
+					}
 				}
 			}
 		}

--- a/src/java/growthcraft/milk/eventhandler/EventHandlerOnBabyCowDeath.java
+++ b/src/java/growthcraft/milk/eventhandler/EventHandlerOnBabyCowDeath.java
@@ -51,8 +51,10 @@ public class EventHandlerOnBabyCowDeath
 					final int count = RandomUtils.range(rng, GrowthCraftMilk.getConfig().stomachMinDropped, GrowthCraftMilk.getConfig().stomachMaxDropped);
 					if (count > 0)
 					{
-						final ItemStack stack = GrowthCraftMilk.items.stomach.asStack(count);
-						ItemUtils.spawnItemStackAtEntity(stack, event.entityLiving, rng);
+						if (!event.entity.worldObj.isRemote) {
+							final ItemStack stack = GrowthCraftMilk.items.stomach.asStack(count);
+							ItemUtils.spawnItemStackAtEntity(stack, event.entityLiving, rng);
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## 2.7.3 Changes

Special thanks to @moxventura for pointing out the misunderstanding with WeightedRandom and offering a patch for the stomach drop bug.

Added all cheese block variants to creative tab.

## Related

Closes #414 - Stomach drop bug
Closes #431 - Fishtrap Loots too OP.

## Builds

Unfortunately my dropbox is currently full and I can't seem to remove anything, all builds will be provided via mediafire, sorry for the inconvenience.

**2017-09-19 @ 10:01:02 EST** 049f0929 [2.7.2 - Download (mediafire)](http://www.mediafire.com/file/q75i9fx577a637w/growthcraft-1.7.10-2.7.2-complete--049f0929-b2.jar)
> #### Checksums
> **MD5**: a3e62c333f519d58a1e383a5009590ad
> **SHA1**: a759dd8f13d278127179f8fbecc2202a6ac87809
> **SHA256**: f47b7c95674417b8dca114835df2bdfb6422050ed59f9af9159aaf228a746c6e
>

## Old Builds

Ain't nobody here but us chickens.

## Change Log

* Adjusts fishtrap loot weights and catch group weights to the suggested by @moxventura
* Stomach drop fix by @moxventura

## Notes

@Alatyami Give this a quick review, when and if you have the time, once that's over merge and do a patch release I guess.